### PR TITLE
feat: Slice 1 web — OAuth, login, dashboard

### DIFF
--- a/api/src/controllers/authController.ts
+++ b/api/src/controllers/authController.ts
@@ -1,0 +1,82 @@
+import { Request, Response } from 'express';
+import * as authService from '../services/authService.js';
+
+export async function sendMagicLink(req: Request, res: Response): Promise<void> {
+  try {
+    const { email } = req.body as { email?: string };
+    if (!email || typeof email !== 'string') {
+      res.status(400).json({
+        error: { code: 'VALIDATION_ERROR', message: 'Email is required' },
+      });
+      return;
+    }
+
+    const result = await authService.generateMagicLink(email);
+    res.json({ data: result });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Unknown error';
+    if (message === 'DOMAIN_NOT_ALLOWED') {
+      res.status(403).json({
+        error: {
+          code: 'DOMAIN_NOT_ALLOWED',
+          message: 'Email domain is not authorized',
+        },
+      });
+      return;
+    }
+    res.status(500).json({
+      error: { code: 'INTERNAL_ERROR', message: 'Failed to generate magic link' },
+    });
+  }
+}
+
+export async function verifyToken(req: Request, res: Response): Promise<void> {
+  try {
+    const { token } = req.query as { token?: string };
+    if (!token) {
+      res.status(400).json({
+        error: { code: 'VALIDATION_ERROR', message: 'Token is required' },
+      });
+      return;
+    }
+
+    const result = await authService.verifyToken(token);
+
+    // Set httpOnly cookie
+    res.cookie('token', result.token, {
+      httpOnly: true,
+      secure: process.env.NODE_ENV === 'production',
+      sameSite: 'lax',
+      maxAge: 7 * 24 * 60 * 60 * 1000, // 7 days
+    });
+
+    res.json({ data: { user: result.user } });
+  } catch {
+    res.status(401).json({
+      error: { code: 'INVALID_TOKEN', message: 'Invalid or expired token' },
+    });
+  }
+}
+
+export async function getMe(req: Request, res: Response): Promise<void> {
+  try {
+    if (!req.user) {
+      res.status(401).json({
+        error: { code: 'UNAUTHORIZED', message: 'Not authenticated' },
+      });
+      return;
+    }
+
+    const user = await authService.getCurrentUser(req.user.userId);
+    res.json({ data: user });
+  } catch {
+    res.status(401).json({
+      error: { code: 'UNAUTHORIZED', message: 'User not found' },
+    });
+  }
+}
+
+export function logout(_req: Request, res: Response): void {
+  res.clearCookie('token');
+  res.json({ data: { message: 'Logged out' } });
+}

--- a/api/src/controllers/botController.ts
+++ b/api/src/controllers/botController.ts
@@ -1,0 +1,115 @@
+import { Request, Response } from 'express';
+import { z } from 'zod';
+import * as botService from '../services/botService.js';
+
+const createBotSchema = z.object({
+  prompt: z.string().min(1, 'Prompt is required'),
+  postMode: z.enum(['auto', 'manual']),
+  postsPerDay: z.number().int().min(1).max(15),
+  minIntervalHours: z.number().int().min(1).max(15),
+  preferredHoursStart: z.number().int().min(0).max(23),
+  preferredHoursEnd: z.number().int().min(1).max(24),
+});
+
+const updateBotSchema = z.object({
+  prompt: z.string().min(1).optional(),
+  postMode: z.enum(['auto', 'manual']).optional(),
+  postsPerDay: z.number().int().min(1).max(15).optional(),
+  minIntervalHours: z.number().int().min(1).max(15).optional(),
+  preferredHoursStart: z.number().int().min(0).max(23).optional(),
+  preferredHoursEnd: z.number().int().min(1).max(24).optional(),
+  active: z.boolean().optional(),
+});
+
+export async function getMyBot(req: Request, res: Response): Promise<void> {
+  try {
+    if (!req.user) {
+      res.status(401).json({
+        error: { code: 'UNAUTHORIZED', message: 'Not authenticated' },
+      });
+      return;
+    }
+
+    const bot = await botService.getBotForUser(req.user.userId);
+    res.json({ data: bot });
+  } catch {
+    res.status(500).json({
+      error: { code: 'INTERNAL_ERROR', message: 'Failed to fetch bot' },
+    });
+  }
+}
+
+export async function createMyBot(req: Request, res: Response): Promise<void> {
+  try {
+    if (!req.user) {
+      res.status(401).json({
+        error: { code: 'UNAUTHORIZED', message: 'Not authenticated' },
+      });
+      return;
+    }
+
+    const parsed = createBotSchema.safeParse(req.body);
+    if (!parsed.success) {
+      res.status(422).json({
+        error: {
+          code: 'VALIDATION_ERROR',
+          message: 'Invalid request body',
+          details: parsed.error.flatten(),
+        },
+      });
+      return;
+    }
+
+    const bot = await botService.createBot(req.user.userId, parsed.data);
+    res.status(201).json({ data: bot });
+  } catch {
+    res.status(500).json({
+      error: { code: 'INTERNAL_ERROR', message: 'Failed to create bot' },
+    });
+  }
+}
+
+export async function updateMyBot(req: Request, res: Response): Promise<void> {
+  try {
+    if (!req.user) {
+      res.status(401).json({
+        error: { code: 'UNAUTHORIZED', message: 'Not authenticated' },
+      });
+      return;
+    }
+
+    const parsed = updateBotSchema.safeParse(req.body);
+    if (!parsed.success) {
+      res.status(422).json({
+        error: {
+          code: 'VALIDATION_ERROR',
+          message: 'Invalid request body',
+          details: parsed.error.flatten(),
+        },
+      });
+      return;
+    }
+
+    const botId = req.params.botId;
+    if (!botId || typeof botId !== 'string') {
+      res.status(400).json({
+        error: { code: 'VALIDATION_ERROR', message: 'Bot ID is required' },
+      });
+      return;
+    }
+
+    const bot = await botService.updateBot(botId, req.user.userId, parsed.data);
+    res.json({ data: bot });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Unknown error';
+    if (message === 'BOT_NOT_FOUND') {
+      res.status(404).json({
+        error: { code: 'NOT_FOUND', message: 'Bot not found' },
+      });
+      return;
+    }
+    res.status(500).json({
+      error: { code: 'INTERNAL_ERROR', message: 'Failed to update bot' },
+    });
+  }
+}

--- a/api/src/controllers/xOAuthController.ts
+++ b/api/src/controllers/xOAuthController.ts
@@ -1,0 +1,73 @@
+import { Request, Response } from 'express';
+import * as xOAuthService from '../services/xOAuthService.js';
+import * as botService from '../services/botService.js';
+
+export async function initiateConnect(req: Request, res: Response): Promise<void> {
+  try {
+    const { botId } = req.query as { botId?: string };
+    if (!botId) {
+      res.status(400).json({
+        error: { code: 'VALIDATION_ERROR', message: 'botId is required' },
+      });
+      return;
+    }
+
+    if (!req.user) {
+      res.status(401).json({
+        error: { code: 'UNAUTHORIZED', message: 'Not authenticated' },
+      });
+      return;
+    }
+
+    const callbackUrl =
+      process.env.X_OAUTH_CALLBACK_URL || 'http://localhost:3001/api/auth/x/callback';
+
+    const { redirectUrl } = await xOAuthService.getRequestToken(
+      callbackUrl,
+      botId,
+      req.user.userId,
+    );
+
+    res.json({ data: { redirectUrl } });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Unknown error';
+    res.status(500).json({
+      error: {
+        code: 'OAUTH_ERROR',
+        message: `Failed to initiate X OAuth: ${message}`,
+      },
+    });
+  }
+}
+
+export async function handleCallback(req: Request, res: Response): Promise<void> {
+  try {
+    const { oauth_token, oauth_verifier } = req.query as {
+      oauth_token?: string;
+      oauth_verifier?: string;
+    };
+
+    if (!oauth_token || !oauth_verifier) {
+      res.status(400).json({
+        error: {
+          code: 'VALIDATION_ERROR',
+          message: 'Missing oauth_token or oauth_verifier',
+        },
+      });
+      return;
+    }
+
+    const { accessToken, accessSecret, screenName, botId, userId } =
+      await xOAuthService.exchangeAccessToken(oauth_token, oauth_verifier);
+
+    await botService.updateBotXCredentials(botId, userId, accessToken, accessSecret, screenName);
+
+    // Redirect to dashboard after successful connection
+    const appUrl = process.env.APP_URL || 'http://localhost:3000';
+    res.redirect(`${appUrl}/dashboard?xConnected=true`);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Unknown error';
+    const appUrl = process.env.APP_URL || 'http://localhost:3000';
+    res.redirect(`${appUrl}/dashboard?xError=${encodeURIComponent(message)}`);
+  }
+}

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -1,20 +1,33 @@
-import express from "express";
-import cors from "cors";
-import helmet from "helmet";
-import cookieParser from "cookie-parser";
+import express from 'express';
+import cors from 'cors';
+import helmet from 'helmet';
+import cookieParser from 'cookie-parser';
+import authRoutes from './routes/authRoutes.js';
+import xOAuthRoutes from './routes/xOAuthRoutes.js';
+import botRoutes from './routes/botRoutes.js';
 
 const app = express();
 
 // Middleware
 app.use(helmet());
-app.use(cors());
+app.use(
+  cors({
+    origin: process.env.APP_URL || 'http://localhost:3000',
+    credentials: true,
+  }),
+);
 app.use(cookieParser());
 app.use(express.json());
 
 // Health check
-app.get("/health", (_req, res) => {
-  res.json({ status: "ok", timestamp: new Date().toISOString() });
+app.get('/health', (_req, res) => {
+  res.json({ status: 'ok', timestamp: new Date().toISOString() });
 });
+
+// Routes
+app.use('/api/auth', authRoutes);
+app.use('/api/auth/x', xOAuthRoutes);
+app.use('/api/bots', botRoutes);
 
 // Start server
 const PORT = process.env.PORT || 3001;

--- a/api/src/middleware/auth.ts
+++ b/api/src/middleware/auth.ts
@@ -1,0 +1,39 @@
+import { Request, Response, NextFunction } from 'express';
+import jwt from 'jsonwebtoken';
+
+const JWT_SECRET = process.env.JWT_SECRET || 'dev-secret-change-me';
+
+export interface AuthPayload {
+  userId: string;
+  email: string;
+}
+
+declare global {
+  // eslint-disable-next-line @typescript-eslint/no-namespace
+  namespace Express {
+    interface Request {
+      user?: AuthPayload;
+    }
+  }
+}
+
+export function requireAuth(req: Request, res: Response, next: NextFunction): void {
+  const token = req.cookies?.token || req.headers.authorization?.replace('Bearer ', '');
+
+  if (!token) {
+    res.status(401).json({
+      error: { code: 'UNAUTHORIZED', message: 'Authentication required' },
+    });
+    return;
+  }
+
+  try {
+    const payload = jwt.verify(token, JWT_SECRET) as AuthPayload;
+    req.user = payload;
+    next();
+  } catch {
+    res.status(401).json({
+      error: { code: 'UNAUTHORIZED', message: 'Invalid or expired token' },
+    });
+  }
+}

--- a/api/src/routes/authRoutes.ts
+++ b/api/src/routes/authRoutes.ts
@@ -1,0 +1,19 @@
+import { Router } from 'express';
+import * as authController from '../controllers/authController.js';
+import { requireAuth } from '../middleware/auth.js';
+
+const router = Router();
+
+// POST /api/auth/magic-link — send magic link email
+router.post('/magic-link', authController.sendMagicLink);
+
+// GET /api/auth/verify — verify magic link token
+router.get('/verify', authController.verifyToken);
+
+// GET /api/auth/me — get current user
+router.get('/me', requireAuth, authController.getMe);
+
+// POST /api/auth/logout — logout
+router.post('/logout', authController.logout);
+
+export default router;

--- a/api/src/routes/botRoutes.ts
+++ b/api/src/routes/botRoutes.ts
@@ -1,0 +1,16 @@
+import { Router } from 'express';
+import * as botController from '../controllers/botController.js';
+import { requireAuth } from '../middleware/auth.js';
+
+const router = Router();
+
+// GET /api/bots/me — get current user's bot
+router.get('/me', requireAuth, botController.getMyBot);
+
+// POST /api/bots — create bot
+router.post('/', requireAuth, botController.createMyBot);
+
+// PATCH /api/bots/:botId — update bot
+router.patch('/:botId', requireAuth, botController.updateMyBot);
+
+export default router;

--- a/api/src/routes/xOAuthRoutes.ts
+++ b/api/src/routes/xOAuthRoutes.ts
@@ -1,0 +1,13 @@
+import { Router } from 'express';
+import * as xOAuthController from '../controllers/xOAuthController.js';
+import { requireAuth } from '../middleware/auth.js';
+
+const router = Router();
+
+// GET /api/auth/x/connect?botId=... — initiate X OAuth 1.0a flow
+router.get('/connect', requireAuth, xOAuthController.initiateConnect);
+
+// GET /api/auth/x/callback — handle callback from X
+router.get('/callback', xOAuthController.handleCallback);
+
+export default router;

--- a/api/src/services/authService.ts
+++ b/api/src/services/authService.ts
@@ -1,0 +1,83 @@
+import jwt from 'jsonwebtoken';
+import { PrismaClient } from '@prisma/client';
+const ALLOWED_DOMAINS = ['thestartupfactory.tech', 'ehe.ai'] as const;
+
+const JWT_SECRET = process.env.JWT_SECRET || 'dev-secret-change-me';
+const prisma = new PrismaClient();
+
+function isAllowedDomain(email: string): boolean {
+  const domain = email.split('@')[1]?.toLowerCase();
+  return (ALLOWED_DOMAINS as readonly string[]).includes(domain);
+}
+
+export async function generateMagicLink(email: string): Promise<{
+  message: string;
+  magicLink?: string;
+}> {
+  if (!isAllowedDomain(email)) {
+    throw new Error('DOMAIN_NOT_ALLOWED');
+  }
+
+  // Find or create user
+  let user = await prisma.user.findUnique({ where: { email } });
+  if (!user) {
+    user = await prisma.user.create({
+      data: {
+        email,
+        name: email.split('@')[0],
+      },
+    });
+  }
+
+  const token = jwt.sign({ userId: user.id, email: user.email }, JWT_SECRET, {
+    expiresIn: '15m',
+  });
+
+  const baseUrl = process.env.APP_URL || 'http://localhost:3000';
+  const magicLink = `${baseUrl}/auth/verify?token=${token}`;
+
+  // In production, send email here. For now, return the link.
+  return {
+    message: 'Magic link generated! Check the API response.',
+    magicLink,
+  };
+}
+
+export async function verifyToken(token: string): Promise<{
+  token: string;
+  user: { id: string; email: string; name: string };
+}> {
+  const payload = jwt.verify(token, JWT_SECRET) as {
+    userId: string;
+    email: string;
+  };
+
+  const user = await prisma.user.findUnique({
+    where: { id: payload.userId },
+    select: { id: true, email: true, name: true },
+  });
+
+  if (!user) {
+    throw new Error('USER_NOT_FOUND');
+  }
+
+  // Issue a longer-lived session token
+  const sessionToken = jwt.sign({ userId: user.id, email: user.email }, JWT_SECRET, {
+    expiresIn: '7d',
+  });
+
+  return { token: sessionToken, user };
+}
+
+export async function getCurrentUser(userId: string) {
+  const user = await prisma.user.findUnique({
+    where: { id: userId },
+    select: { id: true, email: true, name: true, createdAt: true },
+  });
+
+  if (!user) {
+    throw new Error('USER_NOT_FOUND');
+  }
+
+  return user;
+}

--- a/api/src/services/botService.ts
+++ b/api/src/services/botService.ts
@@ -1,0 +1,123 @@
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+export async function getBotForUser(userId: string) {
+  return prisma.bot.findFirst({
+    where: { userId },
+    select: {
+      id: true,
+      xAccountHandle: true,
+      prompt: true,
+      postMode: true,
+      postsPerDay: true,
+      minIntervalHours: true,
+      preferredHoursStart: true,
+      preferredHoursEnd: true,
+      active: true,
+      createdAt: true,
+    },
+  });
+}
+
+export async function createBot(
+  userId: string,
+  data: {
+    prompt: string;
+    postMode: string;
+    postsPerDay: number;
+    minIntervalHours: number;
+    preferredHoursStart: number;
+    preferredHoursEnd: number;
+  },
+) {
+  return prisma.bot.create({
+    data: {
+      userId,
+      xAccessToken: '',
+      xAccessSecret: '',
+      xAccountHandle: '',
+      ...data,
+      active: true,
+    },
+    select: {
+      id: true,
+      xAccountHandle: true,
+      prompt: true,
+      postMode: true,
+      postsPerDay: true,
+      minIntervalHours: true,
+      preferredHoursStart: true,
+      preferredHoursEnd: true,
+      active: true,
+      createdAt: true,
+    },
+  });
+}
+
+export async function updateBot(
+  botId: string,
+  userId: string,
+  data: {
+    prompt?: string;
+    postMode?: string;
+    postsPerDay?: number;
+    minIntervalHours?: number;
+    preferredHoursStart?: number;
+    preferredHoursEnd?: number;
+    active?: boolean;
+  },
+) {
+  // Verify ownership
+  const bot = await prisma.bot.findFirst({
+    where: { id: botId, userId },
+  });
+  if (!bot) {
+    throw new Error('BOT_NOT_FOUND');
+  }
+
+  return prisma.bot.update({
+    where: { id: botId },
+    data,
+    select: {
+      id: true,
+      xAccountHandle: true,
+      prompt: true,
+      postMode: true,
+      postsPerDay: true,
+      minIntervalHours: true,
+      preferredHoursStart: true,
+      preferredHoursEnd: true,
+      active: true,
+      createdAt: true,
+    },
+  });
+}
+
+export async function updateBotXCredentials(
+  botId: string,
+  userId: string,
+  xAccessToken: string,
+  xAccessSecret: string,
+  xAccountHandle: string,
+) {
+  const bot = await prisma.bot.findFirst({
+    where: { id: botId, userId },
+  });
+  if (!bot) {
+    throw new Error('BOT_NOT_FOUND');
+  }
+
+  return prisma.bot.update({
+    where: { id: botId },
+    data: {
+      xAccessToken,
+      xAccessSecret,
+      xAccountHandle,
+    },
+    select: {
+      id: true,
+      xAccountHandle: true,
+    },
+  });
+}

--- a/api/src/services/xOAuthService.ts
+++ b/api/src/services/xOAuthService.ts
@@ -1,0 +1,189 @@
+import crypto from 'crypto';
+
+const X_CONSUMER_KEY = process.env.X_CONSUMER_KEY || '';
+const X_CONSUMER_SECRET = process.env.X_CONSUMER_SECRET || '';
+
+const REQUEST_TOKEN_URL = 'https://api.twitter.com/oauth/request_token';
+const ACCESS_TOKEN_URL = 'https://api.twitter.com/oauth/access_token';
+const AUTHORIZE_URL = 'https://api.twitter.com/oauth/authorize';
+
+// In-memory store for temporary request tokens (oauth_token -> oauth_token_secret + botId)
+const requestTokenStore = new Map<
+  string,
+  { oauthTokenSecret: string; botId: string; userId: string; expiresAt: number }
+>();
+
+// Clean up expired tokens every 5 minutes
+setInterval(
+  () => {
+    const now = Date.now();
+    for (const [key, value] of requestTokenStore.entries()) {
+      if (value.expiresAt < now) {
+        requestTokenStore.delete(key);
+      }
+    }
+  },
+  5 * 60 * 1000,
+);
+
+function percentEncode(str: string): string {
+  return encodeURIComponent(str).replace(
+    /[!'()*]/g,
+    (c) => `%${c.charCodeAt(0).toString(16).toUpperCase()}`,
+  );
+}
+
+function generateNonce(): string {
+  return crypto.randomBytes(16).toString('hex');
+}
+
+function generateTimestamp(): string {
+  return Math.floor(Date.now() / 1000).toString();
+}
+
+function buildOAuthSignature(
+  method: string,
+  url: string,
+  params: Record<string, string>,
+  consumerSecret: string,
+  tokenSecret: string = '',
+): string {
+  const sortedParams = Object.keys(params)
+    .sort()
+    .map((key) => `${percentEncode(key)}=${percentEncode(params[key])}`)
+    .join('&');
+
+  const baseString = `${method.toUpperCase()}&${percentEncode(url)}&${percentEncode(sortedParams)}`;
+  const signingKey = `${percentEncode(consumerSecret)}&${percentEncode(tokenSecret)}`;
+
+  return crypto.createHmac('sha1', signingKey).update(baseString).digest('base64');
+}
+
+function buildAuthorizationHeader(params: Record<string, string>): string {
+  const parts = Object.keys(params)
+    .filter((key) => key.startsWith('oauth_'))
+    .sort()
+    .map((key) => `${percentEncode(key)}="${percentEncode(params[key])}"`)
+    .join(', ');
+  return `OAuth ${parts}`;
+}
+
+export async function getRequestToken(
+  callbackUrl: string,
+  botId: string,
+  userId: string,
+): Promise<{ redirectUrl: string }> {
+  const oauthParams: Record<string, string> = {
+    oauth_callback: callbackUrl,
+    oauth_consumer_key: X_CONSUMER_KEY,
+    oauth_nonce: generateNonce(),
+    oauth_signature_method: 'HMAC-SHA1',
+    oauth_timestamp: generateTimestamp(),
+    oauth_version: '1.0',
+  };
+
+  const signature = buildOAuthSignature('POST', REQUEST_TOKEN_URL, oauthParams, X_CONSUMER_SECRET);
+  oauthParams.oauth_signature = signature;
+
+  const response = await fetch(REQUEST_TOKEN_URL, {
+    method: 'POST',
+    headers: {
+      Authorization: buildAuthorizationHeader(oauthParams),
+    },
+  });
+
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(`Failed to get request token: ${text}`);
+  }
+
+  const body = await response.text();
+  const params = new URLSearchParams(body);
+  const oauthToken = params.get('oauth_token');
+  const oauthTokenSecret = params.get('oauth_token_secret');
+
+  if (!oauthToken || !oauthTokenSecret) {
+    throw new Error('Invalid response from X: missing oauth_token');
+  }
+
+  // Store temporarily (10 minute expiry)
+  requestTokenStore.set(oauthToken, {
+    oauthTokenSecret,
+    botId,
+    userId,
+    expiresAt: Date.now() + 10 * 60 * 1000,
+  });
+
+  const redirectUrl = `${AUTHORIZE_URL}?oauth_token=${oauthToken}`;
+  return { redirectUrl };
+}
+
+export async function exchangeAccessToken(
+  oauthToken: string,
+  oauthVerifier: string,
+): Promise<{
+  accessToken: string;
+  accessSecret: string;
+  screenName: string;
+  botId: string;
+  userId: string;
+}> {
+  const stored = requestTokenStore.get(oauthToken);
+  if (!stored) {
+    throw new Error('Invalid or expired request token');
+  }
+
+  const { oauthTokenSecret, botId, userId } = stored;
+
+  const oauthParams: Record<string, string> = {
+    oauth_consumer_key: X_CONSUMER_KEY,
+    oauth_nonce: generateNonce(),
+    oauth_signature_method: 'HMAC-SHA1',
+    oauth_timestamp: generateTimestamp(),
+    oauth_token: oauthToken,
+    oauth_verifier: oauthVerifier,
+    oauth_version: '1.0',
+  };
+
+  const signature = buildOAuthSignature(
+    'POST',
+    ACCESS_TOKEN_URL,
+    oauthParams,
+    X_CONSUMER_SECRET,
+    oauthTokenSecret,
+  );
+  oauthParams.oauth_signature = signature;
+
+  const response = await fetch(ACCESS_TOKEN_URL, {
+    method: 'POST',
+    headers: {
+      Authorization: buildAuthorizationHeader(oauthParams),
+    },
+  });
+
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(`Failed to exchange access token: ${text}`);
+  }
+
+  const body = await response.text();
+  const params = new URLSearchParams(body);
+  const accessToken = params.get('oauth_token');
+  const accessSecret = params.get('oauth_token_secret');
+  const screenName = params.get('screen_name');
+
+  if (!accessToken || !accessSecret || !screenName) {
+    throw new Error('Invalid response from X: missing access token data');
+  }
+
+  // Clean up request token
+  requestTokenStore.delete(oauthToken);
+
+  return {
+    accessToken,
+    accessSecret,
+    screenName: `@${screenName}`,
+    botId,
+    userId,
+  };
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -972,6 +972,17 @@
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
+    "node_modules/@hookform/resolvers": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-5.2.2.tgz",
+      "integrity": "sha512-A/IxlMLShx3KjV/HeTcTfaMxdwy690+L/ZADoeaTltLx+CVuzkeVIPuybK3jrRfw7YZnmdKsVVHAlEPIAEUNlA==",
+      "dependencies": {
+        "@standard-schema/utils": "^0.3.0"
+      },
+      "peerDependencies": {
+        "react-hook-form": "^7.55.0"
+      }
+    },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.13.0",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.13.0.tgz",
@@ -1760,6 +1771,11 @@
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
       "devOptional": true
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g=="
     },
     "node_modules/@tanstack/history": {
       "version": "1.161.4",
@@ -5160,6 +5176,21 @@
         "react": "^18.3.1"
       }
     },
+    "node_modules/react-hook-form": {
+      "version": "7.71.2",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.71.2.tgz",
+      "integrity": "sha512-1CHvcDYzuRUNOflt4MOq3ZM46AronNJtQ1S7tnX6YN4y72qhgiUItpacZUAQ0TyWYci3yz1X+rXaSxiuEm86PA==",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-hook-form"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17 || ^18 || ^19"
+      }
+    },
     "node_modules/react-is": {
       "version": "19.2.4",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.4.tgz",
@@ -6434,6 +6465,7 @@
       "dependencies": {
         "@emotion/react": "^11.11.0",
         "@emotion/styled": "^11.11.0",
+        "@hookform/resolvers": "^5.2.2",
         "@mui/icons-material": "^5.15.0",
         "@mui/material": "^5.15.0",
         "@tanstack/react-query": "^5.28.0",
@@ -6441,6 +6473,7 @@
         "axios": "^1.6.0",
         "react": "^18.3.0",
         "react-dom": "^18.3.0",
+        "react-hook-form": "^7.71.2",
         "zod": "^3.22.0"
       },
       "devDependencies": {

--- a/web/package.json
+++ b/web/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@emotion/react": "^11.11.0",
     "@emotion/styled": "^11.11.0",
+    "@hookform/resolvers": "^5.2.2",
     "@mui/icons-material": "^5.15.0",
     "@mui/material": "^5.15.0",
     "@tanstack/react-query": "^5.28.0",
@@ -19,6 +20,7 @@
     "axios": "^1.6.0",
     "react": "^18.3.0",
     "react-dom": "^18.3.0",
+    "react-hook-form": "^7.71.2",
     "zod": "^3.22.0"
   },
   "devDependencies": {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,29 +1,8 @@
-import Container from '@mui/material/Container';
-import Box from '@mui/material/Box';
-import Typography from '@mui/material/Typography';
+import { RouterProvider } from '@tanstack/react-router';
+import { router } from './routes/router';
 
 function App() {
-  return (
-    <Container maxWidth="md">
-      <Box
-        sx={{
-          display: 'flex',
-          flexDirection: 'column',
-          alignItems: 'center',
-          justifyContent: 'center',
-          minHeight: '100vh',
-          gap: 2,
-        }}
-      >
-        <Typography variant="h2" component="h1" color="primary" fontWeight={700}>
-          X Bot Platform
-        </Typography>
-        <Typography variant="body1" color="text.secondary">
-          Manage and monitor your X (Twitter) bots from one place.
-        </Typography>
-      </Box>
-    </Container>
-  );
+  return <RouterProvider router={router} />;
 }
 
 export default App;

--- a/web/src/components/AppHeader.tsx
+++ b/web/src/components/AppHeader.tsx
@@ -1,0 +1,45 @@
+import AppBar from '@mui/material/AppBar';
+import Toolbar from '@mui/material/Toolbar';
+import Typography from '@mui/material/Typography';
+import Button from '@mui/material/Button';
+import Box from '@mui/material/Box';
+import { useAuth } from '../hooks/useAuth';
+
+export default function AppHeader() {
+  const { user, isAuthenticated, logout, isLoggingOut } = useAuth();
+
+  return (
+    <AppBar position="static" color="default" elevation={0}>
+      <Toolbar
+        sx={{
+          borderBottom: 1,
+          borderColor: 'divider',
+        }}
+      >
+        <Typography
+          variant="h6"
+          component="div"
+          sx={{ flexGrow: 1, fontWeight: 700 }}
+          color="primary"
+        >
+          X Bot Platform
+        </Typography>
+        {isAuthenticated && user && (
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
+            <Typography variant="body2" color="text.secondary">
+              {user.email}
+            </Typography>
+            <Button
+              variant="outlined"
+              size="small"
+              onClick={() => logout()}
+              disabled={isLoggingOut}
+            >
+              {isLoggingOut ? 'Logging out...' : 'Logout'}
+            </Button>
+          </Box>
+        )}
+      </Toolbar>
+    </AppBar>
+  );
+}

--- a/web/src/components/BotSetupForm.tsx
+++ b/web/src/components/BotSetupForm.tsx
@@ -1,0 +1,215 @@
+import { useForm, Controller } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { z } from 'zod';
+import Box from '@mui/material/Box';
+import TextField from '@mui/material/TextField';
+import Button from '@mui/material/Button';
+import Typography from '@mui/material/Typography';
+import Slider from '@mui/material/Slider';
+import RadioGroup from '@mui/material/RadioGroup';
+import Radio from '@mui/material/Radio';
+import FormControlLabel from '@mui/material/FormControlLabel';
+import FormLabel from '@mui/material/FormLabel';
+import FormControl from '@mui/material/FormControl';
+import MenuItem from '@mui/material/MenuItem';
+import Select from '@mui/material/Select';
+import InputLabel from '@mui/material/InputLabel';
+import Stack from '@mui/material/Stack';
+
+const botFormSchema = z.object({
+  prompt: z.string().min(1, 'Prompt is required'),
+  postMode: z.enum(['auto', 'manual']),
+  postsPerDay: z.number().min(1).max(15),
+  minIntervalHours: z.number().min(1).max(15),
+  preferredHoursStart: z.number().min(0).max(23),
+  preferredHoursEnd: z.number().min(1).max(24),
+});
+
+type BotFormValues = z.infer<typeof botFormSchema>;
+
+interface BotSetupFormProps {
+  defaultValues?: BotFormValues;
+  onSubmit: (values: BotFormValues) => Promise<void>;
+  onCancel?: () => void;
+  isSubmitting: boolean;
+  submitLabel?: string;
+}
+
+const hourOptions = Array.from({ length: 25 }, (_, i) => i);
+
+export default function BotSetupForm({
+  defaultValues,
+  onSubmit,
+  onCancel,
+  isSubmitting,
+  submitLabel = 'Save',
+}: BotSetupFormProps) {
+  const {
+    control,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<BotFormValues>({
+    resolver: zodResolver(botFormSchema),
+    defaultValues: defaultValues ?? {
+      prompt: '',
+      postMode: 'manual',
+      postsPerDay: 3,
+      minIntervalHours: 2,
+      preferredHoursStart: 9,
+      preferredHoursEnd: 18,
+    },
+  });
+
+  return (
+    <Box component="form" onSubmit={handleSubmit(onSubmit)} noValidate sx={{ width: '100%' }}>
+      <Stack spacing={3}>
+        <Controller
+          name="prompt"
+          control={control}
+          render={({ field }) => (
+            <TextField
+              {...field}
+              label="Prompt"
+              placeholder="Topics, tone, and posting style for the AI agent..."
+              multiline
+              minRows={3}
+              maxRows={8}
+              fullWidth
+              error={!!errors.prompt}
+              helperText={errors.prompt?.message}
+            />
+          )}
+        />
+
+        <Controller
+          name="postMode"
+          control={control}
+          render={({ field }) => (
+            <FormControl>
+              <FormLabel>Post Mode</FormLabel>
+              <RadioGroup row {...field}>
+                <FormControlLabel
+                  value="auto"
+                  control={<Radio />}
+                  label="Auto (publish without review)"
+                />
+                <FormControlLabel
+                  value="manual"
+                  control={<Radio />}
+                  label="Manual (review before publishing)"
+                />
+              </RadioGroup>
+            </FormControl>
+          )}
+        />
+
+        <Controller
+          name="postsPerDay"
+          control={control}
+          render={({ field }) => (
+            <Box>
+              <Typography gutterBottom>Posts per day: {field.value}</Typography>
+              <Slider
+                {...field}
+                onChange={(_, val) => field.onChange(val)}
+                min={1}
+                max={15}
+                step={1}
+                marks
+                valueLabelDisplay="auto"
+              />
+            </Box>
+          )}
+        />
+
+        <Controller
+          name="minIntervalHours"
+          control={control}
+          render={({ field }) => (
+            <Box>
+              <Typography gutterBottom>
+                Minimum interval: {field.value} hour
+                {field.value !== 1 ? 's' : ''}
+              </Typography>
+              <Slider
+                {...field}
+                onChange={(_, val) => field.onChange(val)}
+                min={1}
+                max={15}
+                step={1}
+                marks
+                valueLabelDisplay="auto"
+              />
+            </Box>
+          )}
+        />
+
+        <Box
+          sx={{
+            display: 'flex',
+            gap: 2,
+            flexDirection: { xs: 'column', sm: 'row' },
+          }}
+        >
+          <Controller
+            name="preferredHoursStart"
+            control={control}
+            render={({ field }) => (
+              <FormControl fullWidth>
+                <InputLabel>Preferred Start Hour</InputLabel>
+                <Select
+                  {...field}
+                  label="Preferred Start Hour"
+                  onChange={(e) => field.onChange(Number(e.target.value))}
+                >
+                  {hourOptions.slice(0, 24).map((h) => (
+                    <MenuItem key={h} value={h}>
+                      {h.toString().padStart(2, '0')}:00
+                    </MenuItem>
+                  ))}
+                </Select>
+              </FormControl>
+            )}
+          />
+          <Controller
+            name="preferredHoursEnd"
+            control={control}
+            render={({ field }) => (
+              <FormControl fullWidth>
+                <InputLabel>Preferred End Hour</InputLabel>
+                <Select
+                  {...field}
+                  label="Preferred End Hour"
+                  onChange={(e) => field.onChange(Number(e.target.value))}
+                >
+                  {hourOptions.slice(1).map((h) => (
+                    <MenuItem key={h} value={h}>
+                      {h.toString().padStart(2, '0')}:00
+                    </MenuItem>
+                  ))}
+                </Select>
+              </FormControl>
+            )}
+          />
+        </Box>
+
+        <Box
+          sx={{
+            display: 'flex',
+            gap: 2,
+            justifyContent: 'flex-end',
+          }}
+        >
+          {onCancel && (
+            <Button variant="outlined" onClick={onCancel} disabled={isSubmitting}>
+              Cancel
+            </Button>
+          )}
+          <Button type="submit" variant="contained" disabled={isSubmitting}>
+            {isSubmitting ? 'Saving...' : submitLabel}
+          </Button>
+        </Box>
+      </Stack>
+    </Box>
+  );
+}

--- a/web/src/hooks/useAuth.ts
+++ b/web/src/hooks/useAuth.ts
@@ -1,0 +1,46 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import apiClient from '../lib/apiClient';
+import { queryKeys } from '../lib/queryKeys';
+
+interface AuthUser {
+  id: string;
+  email: string;
+  name: string;
+  createdAt: string;
+}
+
+export function useAuth() {
+  const queryClient = useQueryClient();
+
+  const {
+    data: user,
+    isLoading,
+    isError,
+  } = useQuery<AuthUser>({
+    queryKey: queryKeys.auth.me,
+    queryFn: async () => {
+      const res = await apiClient.get('/auth/me');
+      return res.data.data;
+    },
+    retry: false,
+    staleTime: 5 * 60 * 1000,
+  });
+
+  const logoutMutation = useMutation({
+    mutationFn: async () => {
+      await apiClient.post('/auth/logout');
+    },
+    onSuccess: () => {
+      queryClient.setQueryData(queryKeys.auth.me, null);
+      queryClient.invalidateQueries({ queryKey: queryKeys.auth.me });
+    },
+  });
+
+  return {
+    user: user ?? null,
+    isLoading,
+    isAuthenticated: !!user && !isError,
+    logout: logoutMutation.mutate,
+    isLoggingOut: logoutMutation.isPending,
+  };
+}

--- a/web/src/hooks/useBot.ts
+++ b/web/src/hooks/useBot.ts
@@ -1,0 +1,82 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import apiClient from '../lib/apiClient';
+import { queryKeys } from '../lib/queryKeys';
+
+interface BotData {
+  id: string;
+  xAccountHandle: string;
+  prompt: string;
+  postMode: string;
+  postsPerDay: number;
+  minIntervalHours: number;
+  preferredHoursStart: number;
+  preferredHoursEnd: number;
+  active: boolean;
+  createdAt: string;
+}
+
+interface CreateBotPayload {
+  prompt: string;
+  postMode: 'auto' | 'manual';
+  postsPerDay: number;
+  minIntervalHours: number;
+  preferredHoursStart: number;
+  preferredHoursEnd: number;
+}
+
+interface UpdateBotPayload {
+  prompt?: string;
+  postMode?: 'auto' | 'manual';
+  postsPerDay?: number;
+  minIntervalHours?: number;
+  preferredHoursStart?: number;
+  preferredHoursEnd?: number;
+  active?: boolean;
+}
+
+export function useBot() {
+  const queryClient = useQueryClient();
+
+  const {
+    data: bot,
+    isLoading,
+    isError,
+  } = useQuery<BotData | null>({
+    queryKey: queryKeys.bots.mine,
+    queryFn: async () => {
+      const res = await apiClient.get('/bots/me');
+      return res.data.data;
+    },
+    retry: false,
+  });
+
+  const createMutation = useMutation({
+    mutationFn: async (payload: CreateBotPayload) => {
+      const res = await apiClient.post('/bots', payload);
+      return res.data.data as BotData;
+    },
+    onSuccess: (data) => {
+      queryClient.setQueryData(queryKeys.bots.mine, data);
+    },
+  });
+
+  const updateMutation = useMutation({
+    mutationFn: async ({ botId, ...payload }: UpdateBotPayload & { botId: string }) => {
+      const res = await apiClient.patch(`/bots/${botId}`, payload);
+      return res.data.data as BotData;
+    },
+    onSuccess: (data) => {
+      queryClient.setQueryData(queryKeys.bots.mine, data);
+    },
+  });
+
+  return {
+    bot: bot ?? null,
+    isLoading,
+    isError,
+    createBot: createMutation.mutateAsync,
+    isCreating: createMutation.isPending,
+    updateBot: updateMutation.mutateAsync,
+    isUpdating: updateMutation.isPending,
+  };
+}

--- a/web/src/lib/apiClient.ts
+++ b/web/src/lib/apiClient.ts
@@ -1,0 +1,11 @@
+import axios from 'axios';
+
+const apiClient = axios.create({
+  baseURL: '/api',
+  withCredentials: true,
+  headers: {
+    'Content-Type': 'application/json',
+  },
+});
+
+export default apiClient;

--- a/web/src/lib/queryKeys.ts
+++ b/web/src/lib/queryKeys.ts
@@ -1,0 +1,11 @@
+export const queryKeys = {
+  auth: {
+    me: ['auth', 'me'] as const,
+  },
+  bots: {
+    mine: ['bots', 'mine'] as const,
+  },
+  posts: {
+    list: (botId: string) => ['posts', 'list', botId] as const,
+  },
+} as const;

--- a/web/src/pages/DashboardPage.tsx
+++ b/web/src/pages/DashboardPage.tsx
@@ -1,0 +1,265 @@
+import { useState } from 'react';
+import Box from '@mui/material/Box';
+import Container from '@mui/material/Container';
+import Typography from '@mui/material/Typography';
+import Button from '@mui/material/Button';
+import Card from '@mui/material/Card';
+import CardContent from '@mui/material/CardContent';
+import Chip from '@mui/material/Chip';
+import Switch from '@mui/material/Switch';
+import FormControlLabel from '@mui/material/FormControlLabel';
+import Alert from '@mui/material/Alert';
+import CircularProgress from '@mui/material/CircularProgress';
+import Stack from '@mui/material/Stack';
+import Divider from '@mui/material/Divider';
+import { useBot } from '../hooks/useBot';
+import BotSetupForm from '../components/BotSetupForm';
+import AppHeader from '../components/AppHeader';
+
+export default function DashboardPage() {
+  const { bot, isLoading, createBot, isCreating, updateBot, isUpdating } = useBot();
+  const [isEditing, setIsEditing] = useState(false);
+  const [showSetup, setShowSetup] = useState(false);
+
+  // Read URL params for X connection status
+  const params = new URLSearchParams(window.location.search);
+  const xConnected = params.get('xConnected');
+  const xError = params.get('xError');
+
+  if (isLoading) {
+    return (
+      <>
+        <AppHeader />
+        <Container maxWidth="md">
+          <Box
+            sx={{
+              display: 'flex',
+              justifyContent: 'center',
+              alignItems: 'center',
+              minHeight: '60vh',
+            }}
+          >
+            <CircularProgress />
+          </Box>
+        </Container>
+      </>
+    );
+  }
+
+  return (
+    <>
+      <AppHeader />
+      <Container maxWidth="md" sx={{ py: { xs: 2, sm: 4 } }}>
+        <Typography variant="h4" component="h1" sx={{ mb: 3 }}>
+          Dashboard
+        </Typography>
+
+        {xConnected && (
+          <Alert severity="success" sx={{ mb: 2 }}>
+            X account connected successfully!
+          </Alert>
+        )}
+        {xError && (
+          <Alert severity="error" sx={{ mb: 2 }}>
+            Failed to connect X account: {xError}
+          </Alert>
+        )}
+
+        {!bot && !showSetup && (
+          <Card>
+            <CardContent
+              sx={{
+                display: 'flex',
+                flexDirection: 'column',
+                alignItems: 'center',
+                py: 6,
+                gap: 2,
+              }}
+            >
+              <Typography variant="h5" color="text.secondary">
+                No bot configured yet
+              </Typography>
+              <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+                Set up your AI-powered X bot to start automating your posts.
+              </Typography>
+              <Button variant="contained" size="large" onClick={() => setShowSetup(true)}>
+                Set Up Your Bot
+              </Button>
+            </CardContent>
+          </Card>
+        )}
+
+        {!bot && showSetup && (
+          <Card>
+            <CardContent>
+              <Typography variant="h5" sx={{ mb: 3 }}>
+                Bot Setup
+              </Typography>
+              <BotSetupForm
+                onSubmit={async (values) => {
+                  await createBot(values);
+                  setShowSetup(false);
+                }}
+                onCancel={() => setShowSetup(false)}
+                isSubmitting={isCreating}
+                submitLabel="Create Bot"
+              />
+            </CardContent>
+          </Card>
+        )}
+
+        {bot && !isEditing && (
+          <Stack spacing={3}>
+            <Card>
+              <CardContent>
+                <Box
+                  sx={{
+                    display: 'flex',
+                    justifyContent: 'space-between',
+                    alignItems: 'center',
+                    flexWrap: 'wrap',
+                    gap: 2,
+                    mb: 2,
+                  }}
+                >
+                  <Box
+                    sx={{
+                      display: 'flex',
+                      alignItems: 'center',
+                      gap: 1,
+                    }}
+                  >
+                    <Typography variant="h5">Bot Status</Typography>
+                    <Chip
+                      label={bot.active ? 'Active' : 'Inactive'}
+                      color={bot.active ? 'success' : 'default'}
+                      size="small"
+                    />
+                  </Box>
+                  <FormControlLabel
+                    control={
+                      <Switch
+                        checked={bot.active}
+                        onChange={async () => {
+                          await updateBot({
+                            botId: bot.id,
+                            active: !bot.active,
+                          });
+                        }}
+                        disabled={isUpdating}
+                      />
+                    }
+                    label={bot.active ? 'Active' : 'Inactive'}
+                  />
+                </Box>
+
+                {bot.xAccountHandle ? (
+                  <Box
+                    sx={{
+                      display: 'flex',
+                      alignItems: 'center',
+                      gap: 1,
+                      mb: 2,
+                    }}
+                  >
+                    <Typography variant="body2" color="text.secondary">
+                      Connected X account:
+                    </Typography>
+                    <Chip label={bot.xAccountHandle} variant="outlined" />
+                  </Box>
+                ) : (
+                  <Button
+                    variant="outlined"
+                    href={`/api/auth/x/connect?botId=${bot.id}`}
+                    sx={{ mb: 2 }}
+                  >
+                    Connect X Account
+                  </Button>
+                )}
+
+                <Divider sx={{ my: 2 }} />
+
+                <Stack spacing={1.5}>
+                  <Box>
+                    <Typography variant="caption" color="text.secondary" component="div">
+                      Prompt
+                    </Typography>
+                    <Typography variant="body2">{bot.prompt}</Typography>
+                  </Box>
+                  <Box
+                    sx={{
+                      display: 'flex',
+                      gap: 3,
+                      flexWrap: 'wrap',
+                    }}
+                  >
+                    <Box>
+                      <Typography variant="caption" color="text.secondary" component="div">
+                        Post Mode
+                      </Typography>
+                      <Typography variant="body2">{bot.postMode}</Typography>
+                    </Box>
+                    <Box>
+                      <Typography variant="caption" color="text.secondary" component="div">
+                        Posts / Day
+                      </Typography>
+                      <Typography variant="body2">{bot.postsPerDay}</Typography>
+                    </Box>
+                    <Box>
+                      <Typography variant="caption" color="text.secondary" component="div">
+                        Min Interval
+                      </Typography>
+                      <Typography variant="body2">{bot.minIntervalHours}h</Typography>
+                    </Box>
+                    <Box>
+                      <Typography variant="caption" color="text.secondary" component="div">
+                        Preferred Hours
+                      </Typography>
+                      <Typography variant="body2">
+                        {bot.preferredHoursStart.toString().padStart(2, '0')}:00
+                        {' - '}
+                        {bot.preferredHoursEnd.toString().padStart(2, '0')}:00
+                      </Typography>
+                    </Box>
+                  </Box>
+                </Stack>
+
+                <Box sx={{ mt: 3, display: 'flex', justifyContent: 'flex-end' }}>
+                  <Button variant="outlined" onClick={() => setIsEditing(true)}>
+                    Edit Configuration
+                  </Button>
+                </Box>
+              </CardContent>
+            </Card>
+          </Stack>
+        )}
+
+        {bot && isEditing && (
+          <Card>
+            <CardContent>
+              <Typography variant="h5" sx={{ mb: 3 }}>
+                Edit Bot Configuration
+              </Typography>
+              <BotSetupForm
+                defaultValues={{
+                  prompt: bot.prompt,
+                  postMode: bot.postMode as 'auto' | 'manual',
+                  postsPerDay: bot.postsPerDay,
+                  minIntervalHours: bot.minIntervalHours,
+                  preferredHoursStart: bot.preferredHoursStart,
+                  preferredHoursEnd: bot.preferredHoursEnd,
+                }}
+                onSubmit={async (values) => {
+                  await updateBot({ botId: bot.id, ...values });
+                  setIsEditing(false);
+                }}
+                onCancel={() => setIsEditing(false)}
+                isSubmitting={isUpdating}
+              />
+            </CardContent>
+          </Card>
+        )}
+      </Container>
+    </>
+  );
+}

--- a/web/src/pages/LoginPage.tsx
+++ b/web/src/pages/LoginPage.tsx
@@ -1,0 +1,125 @@
+import { useState } from 'react';
+import { useMutation } from '@tanstack/react-query';
+import Box from '@mui/material/Box';
+import Container from '@mui/material/Container';
+import Typography from '@mui/material/Typography';
+import TextField from '@mui/material/TextField';
+import Button from '@mui/material/Button';
+import Alert from '@mui/material/Alert';
+import Paper from '@mui/material/Paper';
+import apiClient from '../lib/apiClient';
+
+const ALLOWED_DOMAINS = ['thestartupfactory.tech', 'ehe.ai'];
+
+function validateEmailDomain(email: string): string | null {
+  if (!email) return 'Email is required';
+  const domain = email.split('@')[1]?.toLowerCase();
+  if (!domain || !ALLOWED_DOMAINS.includes(domain)) {
+    return `Only emails from ${ALLOWED_DOMAINS.join(', ')} are allowed.`;
+  }
+  return null;
+}
+
+export default function LoginPage() {
+  const [email, setEmail] = useState('');
+  const [clientError, setClientError] = useState<string | null>(null);
+  const [successMessage, setSuccessMessage] = useState<string | null>(null);
+
+  const magicLinkMutation = useMutation({
+    mutationFn: async (emailValue: string) => {
+      const res = await apiClient.post('/auth/magic-link', {
+        email: emailValue,
+      });
+      return res.data.data as { message: string; magicLink?: string };
+    },
+    onSuccess: (data) => {
+      setSuccessMessage(
+        data.magicLink
+          ? `Magic link generated! Check the API response. Link: ${data.magicLink}`
+          : 'Magic link generated! Check the API response.',
+      );
+    },
+  });
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    setClientError(null);
+    setSuccessMessage(null);
+
+    const domainError = validateEmailDomain(email);
+    if (domainError) {
+      setClientError(domainError);
+      return;
+    }
+
+    magicLinkMutation.mutate(email);
+  };
+
+  return (
+    <Container maxWidth="sm">
+      <Box
+        sx={{
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          justifyContent: 'center',
+          minHeight: '100vh',
+          py: 4,
+        }}
+      >
+        <Paper
+          sx={{
+            p: { xs: 3, sm: 4 },
+            width: '100%',
+            maxWidth: 440,
+          }}
+        >
+          <Typography variant="h3" component="h1" sx={{ mb: 1, textAlign: 'center' }}>
+            X Bot Platform
+          </Typography>
+          <Typography variant="body2" color="text.secondary" sx={{ mb: 3, textAlign: 'center' }}>
+            Sign in with your work email to get started.
+          </Typography>
+
+          {clientError && (
+            <Alert severity="error" sx={{ mb: 2 }}>
+              {clientError}
+            </Alert>
+          )}
+          {magicLinkMutation.isError && (
+            <Alert severity="error" sx={{ mb: 2 }}>
+              Failed to send magic link. Please try again.
+            </Alert>
+          )}
+          {successMessage && (
+            <Alert severity="success" sx={{ mb: 2 }}>
+              {successMessage}
+            </Alert>
+          )}
+
+          <Box component="form" onSubmit={handleSubmit} noValidate>
+            <TextField
+              label="Work Email"
+              type="email"
+              fullWidth
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              placeholder="you@thestartupfactory.tech"
+              sx={{ mb: 2 }}
+              disabled={magicLinkMutation.isPending}
+            />
+            <Button
+              type="submit"
+              variant="contained"
+              fullWidth
+              size="large"
+              disabled={magicLinkMutation.isPending}
+            >
+              {magicLinkMutation.isPending ? 'Sending...' : 'Send Magic Link'}
+            </Button>
+          </Box>
+        </Paper>
+      </Box>
+    </Container>
+  );
+}

--- a/web/src/pages/PostsPage.tsx
+++ b/web/src/pages/PostsPage.tsx
@@ -1,0 +1,29 @@
+import Container from '@mui/material/Container';
+import Typography from '@mui/material/Typography';
+import Box from '@mui/material/Box';
+import AppHeader from '../components/AppHeader';
+
+export default function PostsPage() {
+  return (
+    <>
+      <AppHeader />
+      <Container maxWidth="md" sx={{ py: { xs: 2, sm: 4 } }}>
+        <Typography variant="h4" component="h1" sx={{ mb: 3 }}>
+          Posts
+        </Typography>
+        <Box
+          sx={{
+            display: 'flex',
+            justifyContent: 'center',
+            alignItems: 'center',
+            minHeight: '40vh',
+          }}
+        >
+          <Typography variant="body1" color="text.secondary">
+            Post management coming soon.
+          </Typography>
+        </Box>
+      </Container>
+    </>
+  );
+}

--- a/web/src/pages/VerifyPage.tsx
+++ b/web/src/pages/VerifyPage.tsx
@@ -1,0 +1,84 @@
+import { useEffect, useRef } from 'react';
+import { useNavigate } from '@tanstack/react-router';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import Box from '@mui/material/Box';
+import Container from '@mui/material/Container';
+import Typography from '@mui/material/Typography';
+import CircularProgress from '@mui/material/CircularProgress';
+import Alert from '@mui/material/Alert';
+import Button from '@mui/material/Button';
+import apiClient from '../lib/apiClient';
+import { queryKeys } from '../lib/queryKeys';
+
+export default function VerifyPage() {
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const hasAttempted = useRef(false);
+
+  const verifyMutation = useMutation({
+    mutationFn: async (token: string) => {
+      const res = await apiClient.get(`/auth/verify?token=${token}`);
+      return res.data.data;
+    },
+    onSuccess: (data) => {
+      queryClient.setQueryData(queryKeys.auth.me, data.user);
+      navigate({ to: '/dashboard' });
+    },
+  });
+
+  useEffect(() => {
+    if (hasAttempted.current) return;
+    hasAttempted.current = true;
+
+    const params = new URLSearchParams(window.location.search);
+    const token = params.get('token');
+    if (token) {
+      verifyMutation.mutate(token);
+    }
+  }, []);
+
+  const params = new URLSearchParams(window.location.search);
+  const hasToken = params.get('token');
+
+  return (
+    <Container maxWidth="sm">
+      <Box
+        sx={{
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          justifyContent: 'center',
+          minHeight: '100vh',
+          gap: 2,
+        }}
+      >
+        {verifyMutation.isPending && (
+          <>
+            <CircularProgress />
+            <Typography>Verifying your login...</Typography>
+          </>
+        )}
+        {verifyMutation.isError && (
+          <>
+            <Alert severity="error" sx={{ width: '100%' }}>
+              Verification failed. The link may have expired.
+            </Alert>
+            <Button variant="contained" onClick={() => navigate({ to: '/login' })}>
+              Back to Login
+            </Button>
+          </>
+        )}
+        {!hasToken && !verifyMutation.isPending && !verifyMutation.isError && (
+          <>
+            <Alert severity="warning" sx={{ width: '100%' }}>
+              No verification token found.
+            </Alert>
+            <Button variant="contained" onClick={() => navigate({ to: '/login' })}>
+              Back to Login
+            </Button>
+          </>
+        )}
+      </Box>
+    </Container>
+  );
+}

--- a/web/src/routes/router.tsx
+++ b/web/src/routes/router.tsx
@@ -1,0 +1,122 @@
+import { lazy, Suspense } from 'react';
+import {
+  createRouter,
+  createRootRoute,
+  createRoute,
+  Outlet,
+  redirect,
+} from '@tanstack/react-router';
+import CircularProgress from '@mui/material/CircularProgress';
+import Box from '@mui/material/Box';
+import apiClient from '../lib/apiClient';
+
+const LoginPage = lazy(() => import('../pages/LoginPage'));
+const VerifyPage = lazy(() => import('../pages/VerifyPage'));
+const DashboardPage = lazy(() => import('../pages/DashboardPage'));
+const PostsPage = lazy(() => import('../pages/PostsPage'));
+
+function LoadingFallback() {
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        justifyContent: 'center',
+        alignItems: 'center',
+        minHeight: '100vh',
+      }}
+    >
+      <CircularProgress />
+    </Box>
+  );
+}
+
+async function checkAuth(): Promise<boolean> {
+  try {
+    await apiClient.get('/auth/me');
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+// Root route
+const rootRoute = createRootRoute({
+  component: () => (
+    <Suspense fallback={<LoadingFallback />}>
+      <Outlet />
+    </Suspense>
+  ),
+});
+
+// Login route
+const loginRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: '/login',
+  component: () => <LoginPage />,
+});
+
+// Verify route
+const verifyRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: '/auth/verify',
+  component: () => <VerifyPage />,
+});
+
+// Protected dashboard route
+const dashboardRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: '/dashboard',
+  beforeLoad: async () => {
+    const isAuth = await checkAuth();
+    if (!isAuth) {
+      throw redirect({ to: '/login' });
+    }
+  },
+  component: () => <DashboardPage />,
+});
+
+// Protected posts route
+const postsRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: '/posts',
+  beforeLoad: async () => {
+    const isAuth = await checkAuth();
+    if (!isAuth) {
+      throw redirect({ to: '/login' });
+    }
+  },
+  component: () => <PostsPage />,
+});
+
+// Index route — redirect to dashboard
+const indexRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: '/',
+  beforeLoad: async () => {
+    const isAuth = await checkAuth();
+    if (isAuth) {
+      throw redirect({ to: '/dashboard' });
+    } else {
+      throw redirect({ to: '/login' });
+    }
+  },
+});
+
+// Build route tree
+const routeTree = rootRoute.addChildren([
+  indexRoute,
+  loginRoute,
+  verifyRoute,
+  dashboardRoute,
+  postsRoute,
+]);
+
+// Create router
+export const router = createRouter({ routeTree });
+
+// Type augmentation for TanStack Router
+declare module '@tanstack/react-router' {
+  interface Register {
+    router: typeof router;
+  }
+}


### PR DESCRIPTION
## Summary
- **Issue #3 — X OAuth flow (API):** Added `GET /api/auth/x/connect` and `GET /api/auth/x/callback` endpoints implementing full OAuth 1.0a with HMAC-SHA1 signing. Request tokens stored in-memory with 10-minute expiry. Callback exchanges tokens and stores `xAccessToken`, `xAccessSecret`, `xAccountHandle` on the bot record.
- **Issue #4 — Web login and auth:** Login page with email domain validation (thestartupfactory.tech, ehe.ai), magic link generation, verification page. TanStack Router with protected routes (`/dashboard`, `/posts`) and public routes (`/login`, `/auth/verify`). Auth hook via TanStack Query, logout in header. Axios client with `/api` baseURL and `credentials: 'include'`.
- **Issue #5 — Dashboard and bot setup:** Dashboard with bot status display or setup CTA. Bot config form (prompt, post mode radio, posts/day slider, min interval slider, preferred hours selects) using react-hook-form + zod. Edit mode with save/cancel. Active/inactive toggle. Connect X Account button. X handle display when connected.

Closes #3, Closes #4, Closes #5

## Test plan
- [ ] Login page renders, validates email domains client-side
- [ ] Magic link API returns link in dev mode
- [ ] Verify page exchanges token and redirects to dashboard
- [ ] Protected routes redirect to /login when unauthenticated
- [ ] Dashboard shows setup CTA when no bot exists
- [ ] Bot creation form validates and submits
- [ ] Bot edit mode pre-fills values and saves
- [ ] Active/inactive toggle updates bot
- [ ] Connect X Account button links to OAuth endpoint
- [ ] X OAuth connect endpoint returns redirect URL
- [ ] X OAuth callback stores credentials and redirects to dashboard
- [ ] Logout clears cookie and redirects
- [ ] TypeScript strict: zero errors
- [ ] ESLint: zero errors
- [ ] Prettier: all files formatted

🤖 Generated with [Claude Code](https://claude.com/claude-code)