### PR TITLE
[SLICE-1] Web frontend and X OAuth

### DIFF
--- a/api/src/controllers/xOAuthController.ts
+++ b/api/src/controllers/xOAuthController.ts
@@ -1,0 +1,60 @@
+import { Request, Response, NextFunction } from 'express';
+import { z } from 'zod';
+import { xOAuthService } from '../services/xOAuthService.js';
+import { botRepository } from '../repositories/botRepository.js';
+import { NotFoundError, ForbiddenError } from '../utils/errors.js';
+import { config } from '../config/index.js';
+
+const connectQuerySchema = z.object({
+  botId: z.string().min(1, 'botId is required'),
+});
+
+const callbackQuerySchema = z.object({
+  oauth_token: z.string().min(1),
+  oauth_verifier: z.string().min(1),
+});
+
+export const xOAuthController = {
+  async connect(req: Request, res: Response, next: NextFunction): Promise<void> {
+    try {
+      const userId = req.userId!;
+      const { botId } = connectQuerySchema.parse(req.query);
+
+      const bot = await botRepository.findById(botId);
+      if (!bot) {
+        throw new NotFoundError('Bot not found');
+      }
+      if (bot.userId !== userId) {
+        throw new ForbiddenError('You do not have access to this bot');
+      }
+
+      const { oauthToken } = await xOAuthService.getRequestToken(botId);
+      const authUrl = xOAuthService.generateAuthUrl(oauthToken);
+
+      res.status(200).json({
+        data: { url: authUrl },
+      });
+    } catch (err) {
+      next(err);
+    }
+  },
+
+  async callback(req: Request, res: Response, next: NextFunction): Promise<void> {
+    try {
+      const { oauth_token, oauth_verifier } = callbackQuerySchema.parse(req.query);
+
+      const { accessToken, accessTokenSecret, screenName, botId } =
+        await xOAuthService.getAccessToken(oauth_token, oauth_verifier);
+
+      await botRepository.update(botId, {
+        xAccessToken: accessToken,
+        xAccessSecret: accessTokenSecret,
+        xAccountHandle: screenName,
+      });
+
+      res.redirect(`${config.app.frontendUrl}/dashboard`);
+    } catch (err) {
+      next(err);
+    }
+  },
+};

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -9,6 +9,7 @@ import { notFoundHandler } from './middleware/notFound.js';
 import healthRoutes from './routes/healthRoutes.js';
 import authRoutes from './routes/authRoutes.js';
 import botRoutes from './routes/botRoutes.js';
+import xOAuthRoutes from './routes/xOAuthRoutes.js';
 
 const app = express();
 
@@ -23,6 +24,7 @@ app.use(requestLogger);
 app.use('/api/health', healthRoutes);
 app.use('/api/auth', authRoutes);
 app.use('/api/bots', botRoutes);
+app.use('/api/auth/x', xOAuthRoutes);
 
 // 404 handler for unknown routes
 app.use(notFoundHandler);

--- a/api/src/routes/xOAuthRoutes.ts
+++ b/api/src/routes/xOAuthRoutes.ts
@@ -1,0 +1,13 @@
+import { Router } from 'express';
+import { xOAuthController } from '../controllers/xOAuthController.js';
+import { authMiddleware } from '../middleware/auth.js';
+
+const router = Router();
+
+// Initiate X OAuth - requires auth
+router.get('/connect', authMiddleware, xOAuthController.connect);
+
+// X OAuth callback - public (Twitter redirects here)
+router.get('/callback', xOAuthController.callback);
+
+export default router;

--- a/api/src/services/xOAuthService.ts
+++ b/api/src/services/xOAuthService.ts
@@ -1,0 +1,229 @@
+import crypto from 'node:crypto';
+import { config } from '../config/index.js';
+
+const TWITTER_REQUEST_TOKEN_URL = 'https://api.twitter.com/oauth/request_token';
+const TWITTER_ACCESS_TOKEN_URL = 'https://api.twitter.com/oauth/access_token';
+const TWITTER_AUTHORIZE_URL = 'https://api.twitter.com/oauth/authorize';
+
+type RequestTokenEntry = {
+  token: string;
+  secret: string;
+  botId: string;
+  createdAt: number;
+};
+
+// In-memory store with TTL (10 minutes)
+const REQUEST_TOKEN_TTL_MS = 10 * 60 * 1000;
+const requestTokenStore = new Map<string, RequestTokenEntry>();
+
+function cleanExpiredTokens(): void {
+  const now = Date.now();
+  for (const [key, entry] of requestTokenStore.entries()) {
+    if (now - entry.createdAt > REQUEST_TOKEN_TTL_MS) {
+      requestTokenStore.delete(key);
+    }
+  }
+}
+
+function percentEncode(str: string): string {
+  return encodeURIComponent(str).replace(
+    /[!'()*]/g,
+    (c) => `%${c.charCodeAt(0).toString(16).toUpperCase()}`,
+  );
+}
+
+function generateNonce(): string {
+  return crypto.randomBytes(16).toString('hex');
+}
+
+function generateTimestamp(): string {
+  return Math.floor(Date.now() / 1000).toString();
+}
+
+function buildSignatureBaseString(
+  method: string,
+  url: string,
+  params: Record<string, string>,
+): string {
+  const sortedKeys = Object.keys(params).sort();
+  const paramString = sortedKeys
+    .map((key) => `${percentEncode(key)}=${percentEncode(params[key])}`)
+    .join('&');
+
+  return `${method.toUpperCase()}&${percentEncode(url)}&${percentEncode(paramString)}`;
+}
+
+function signHmacSha1(baseString: string, consumerSecret: string, tokenSecret: string): string {
+  const signingKey = `${percentEncode(consumerSecret)}&${percentEncode(tokenSecret)}`;
+  const hmac = crypto.createHmac('sha1', signingKey);
+  hmac.update(baseString);
+  return hmac.digest('base64');
+}
+
+function buildAuthorizationHeader(params: Record<string, string>): string {
+  const parts = Object.keys(params)
+    .sort()
+    .map((key) => `${percentEncode(key)}="${percentEncode(params[key])}"`)
+    .join(', ');
+  return `OAuth ${parts}`;
+}
+
+async function makeOAuthRequest(
+  method: string,
+  url: string,
+  oauthParams: Record<string, string>,
+  consumerSecret: string,
+  tokenSecret: string,
+  bodyParams?: Record<string, string>,
+): Promise<string> {
+  const allParams = { ...oauthParams, ...bodyParams };
+  const baseString = buildSignatureBaseString(method, url, allParams);
+  const signature = signHmacSha1(baseString, consumerSecret, tokenSecret);
+
+  const headerParams = {
+    ...oauthParams,
+    oauth_signature: signature,
+  };
+
+  const headers: Record<string, string> = {
+    Authorization: buildAuthorizationHeader(headerParams),
+  };
+
+  let body: string | undefined;
+  if (bodyParams && Object.keys(bodyParams).length > 0) {
+    headers['Content-Type'] = 'application/x-www-form-urlencoded';
+    body = Object.entries(bodyParams)
+      .map(([k, v]) => `${percentEncode(k)}=${percentEncode(v)}`)
+      .join('&');
+  }
+
+  const response = await fetch(url, {
+    method,
+    headers,
+    body,
+  });
+
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(`Twitter OAuth request failed: ${response.status} ${text}`);
+  }
+
+  return response.text();
+}
+
+function parseResponseParams(body: string): Record<string, string> {
+  const params: Record<string, string> = {};
+  for (const pair of body.split('&')) {
+    const [key, value] = pair.split('=');
+    params[decodeURIComponent(key)] = decodeURIComponent(value || '');
+  }
+  return params;
+}
+
+export const xOAuthService = {
+  async getRequestToken(botId: string): Promise<{ oauthToken: string }> {
+    cleanExpiredTokens();
+
+    const consumerKey = process.env.X_CONSUMER_KEY || '';
+    const consumerSecret = process.env.X_CONSUMER_SECRET || '';
+    const callbackUrl = `${config.app.baseUrl}/api/auth/x/callback`;
+
+    const oauthParams: Record<string, string> = {
+      oauth_consumer_key: consumerKey,
+      oauth_nonce: generateNonce(),
+      oauth_signature_method: 'HMAC-SHA1',
+      oauth_timestamp: generateTimestamp(),
+      oauth_version: '1.0',
+      oauth_callback: callbackUrl,
+    };
+
+    const responseBody = await makeOAuthRequest(
+      'POST',
+      TWITTER_REQUEST_TOKEN_URL,
+      oauthParams,
+      consumerSecret,
+      '',
+    );
+
+    const parsed = parseResponseParams(responseBody);
+    const oauthToken = parsed['oauth_token'];
+    const oauthTokenSecret = parsed['oauth_token_secret'];
+
+    if (!oauthToken || !oauthTokenSecret) {
+      throw new Error('Failed to obtain request token from Twitter');
+    }
+
+    requestTokenStore.set(oauthToken, {
+      token: oauthToken,
+      secret: oauthTokenSecret,
+      botId,
+      createdAt: Date.now(),
+    });
+
+    return { oauthToken };
+  },
+
+  async getAccessToken(
+    oauthToken: string,
+    oauthVerifier: string,
+  ): Promise<{
+    accessToken: string;
+    accessTokenSecret: string;
+    screenName: string;
+    botId: string;
+  }> {
+    cleanExpiredTokens();
+
+    const entry = requestTokenStore.get(oauthToken);
+    if (!entry) {
+      throw new Error('Invalid or expired request token');
+    }
+
+    requestTokenStore.delete(oauthToken);
+
+    const consumerKey = process.env.X_CONSUMER_KEY || '';
+    const consumerSecret = process.env.X_CONSUMER_SECRET || '';
+
+    const oauthParams: Record<string, string> = {
+      oauth_consumer_key: consumerKey,
+      oauth_nonce: generateNonce(),
+      oauth_signature_method: 'HMAC-SHA1',
+      oauth_timestamp: generateTimestamp(),
+      oauth_token: oauthToken,
+      oauth_version: '1.0',
+    };
+
+    const bodyParams: Record<string, string> = {
+      oauth_verifier: oauthVerifier,
+    };
+
+    const responseBody = await makeOAuthRequest(
+      'POST',
+      TWITTER_ACCESS_TOKEN_URL,
+      oauthParams,
+      consumerSecret,
+      entry.secret,
+      bodyParams,
+    );
+
+    const parsed = parseResponseParams(responseBody);
+    const accessToken = parsed['oauth_token'];
+    const accessTokenSecret = parsed['oauth_token_secret'];
+    const screenName = parsed['screen_name'] || '';
+
+    if (!accessToken || !accessTokenSecret) {
+      throw new Error('Failed to obtain access token from Twitter');
+    }
+
+    return {
+      accessToken,
+      accessTokenSecret,
+      screenName,
+      botId: entry.botId,
+    };
+  },
+
+  generateAuthUrl(oauthToken: string): string {
+    return `${TWITTER_AUTHORIZE_URL}?oauth_token=${percentEncode(oauthToken)}`;
+  },
+};

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,29 +1,10 @@
-import Container from '@mui/material/Container';
-import Box from '@mui/material/Box';
-import Typography from '@mui/material/Typography';
+import { RouterProvider } from '@tanstack/react-router';
+import { createAppRouter } from './routes/router';
+
+const router = createAppRouter();
 
 function App() {
-  return (
-    <Container maxWidth="md">
-      <Box
-        sx={{
-          display: 'flex',
-          flexDirection: 'column',
-          alignItems: 'center',
-          justifyContent: 'center',
-          minHeight: '100vh',
-          gap: 2,
-        }}
-      >
-        <Typography variant="h2" component="h1" color="primary" fontWeight={700}>
-          X Bot Platform
-        </Typography>
-        <Typography variant="body1" color="text.secondary">
-          Manage and monitor your X (Twitter) bots from one place.
-        </Typography>
-      </Box>
-    </Container>
-  );
+  return <RouterProvider router={router} />;
 }
 
 export default App;

--- a/web/src/components/AppHeader.tsx
+++ b/web/src/components/AppHeader.tsx
@@ -1,0 +1,37 @@
+import AppBar from '@mui/material/AppBar';
+import Toolbar from '@mui/material/Toolbar';
+import Typography from '@mui/material/Typography';
+import Button from '@mui/material/Button';
+import Box from '@mui/material/Box';
+import { useAuth, useLogoutMutation } from '../hooks/useAuth';
+
+export default function AppHeader() {
+  const { user } = useAuth();
+  const logoutMutation = useLogoutMutation();
+
+  const handleLogout = () => {
+    logoutMutation.mutate(undefined, {
+      onSuccess: () => {
+        window.location.href = '/login';
+      },
+    });
+  };
+
+  return (
+    <AppBar position="static">
+      <Toolbar>
+        <Typography variant="h6" component="div" sx={{ flexGrow: 1 }}>
+          X Bot Platform
+        </Typography>
+        {user && (
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
+            <Typography variant="body2">{user.email}</Typography>
+            <Button color="inherit" onClick={handleLogout} disabled={logoutMutation.isPending}>
+              Logout
+            </Button>
+          </Box>
+        )}
+      </Toolbar>
+    </AppBar>
+  );
+}

--- a/web/src/components/BotSetupForm.tsx
+++ b/web/src/components/BotSetupForm.tsx
@@ -1,0 +1,184 @@
+import { useState } from 'react';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import FormControl from '@mui/material/FormControl';
+import FormControlLabel from '@mui/material/FormControlLabel';
+import FormLabel from '@mui/material/FormLabel';
+import MenuItem from '@mui/material/MenuItem';
+import Radio from '@mui/material/Radio';
+import RadioGroup from '@mui/material/RadioGroup';
+import Select from '@mui/material/Select';
+import Slider from '@mui/material/Slider';
+import TextField from '@mui/material/TextField';
+import Typography from '@mui/material/Typography';
+import Alert from '@mui/material/Alert';
+import InputLabel from '@mui/material/InputLabel';
+import { z } from 'zod';
+
+const botConfigSchema = z.object({
+  prompt: z.string().min(1, 'Prompt is required'),
+  postMode: z.enum(['auto', 'manual']),
+  postsPerDay: z.number().int().min(1).max(15),
+  minIntervalHours: z.number().int().min(1).max(15),
+  preferredHoursStart: z.number().int().min(0).max(23),
+  preferredHoursEnd: z.number().int().min(1).max(24),
+});
+
+type BotConfigValues = z.infer<typeof botConfigSchema>;
+
+type BotSetupFormProps = {
+  initialValues?: Partial<BotConfigValues>;
+  onSubmit: (values: BotConfigValues) => void;
+  isLoading?: boolean;
+  submitLabel?: string;
+};
+
+const defaultValues: BotConfigValues = {
+  prompt: '',
+  postMode: 'manual',
+  postsPerDay: 3,
+  minIntervalHours: 2,
+  preferredHoursStart: 9,
+  preferredHoursEnd: 18,
+};
+
+export default function BotSetupForm({
+  initialValues,
+  onSubmit,
+  isLoading = false,
+  submitLabel = 'Save',
+}: BotSetupFormProps) {
+  const [values, setValues] = useState<BotConfigValues>({
+    ...defaultValues,
+    ...initialValues,
+  });
+  const [errors, setErrors] = useState<Record<string, string>>({});
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    const result = botConfigSchema.safeParse(values);
+    if (!result.success) {
+      const fieldErrors: Record<string, string> = {};
+      for (const issue of result.error.issues) {
+        const field = issue.path[0];
+        if (typeof field === 'string') {
+          fieldErrors[field] = issue.message;
+        }
+      }
+      setErrors(fieldErrors);
+      return;
+    }
+    setErrors({});
+    onSubmit(result.data);
+  };
+
+  return (
+    <Box
+      component="form"
+      onSubmit={handleSubmit}
+      sx={{ display: 'flex', flexDirection: 'column', gap: 3 }}
+    >
+      <TextField
+        label="Bot Prompt"
+        multiline
+        rows={4}
+        value={values.prompt}
+        onChange={(e) => setValues((v) => ({ ...v, prompt: e.target.value }))}
+        error={!!errors['prompt']}
+        helperText={errors['prompt']}
+        fullWidth
+      />
+
+      <FormControl>
+        <FormLabel>Post Mode</FormLabel>
+        <RadioGroup
+          row
+          value={values.postMode}
+          onChange={(e) =>
+            setValues((v) => ({
+              ...v,
+              postMode: e.target.value as 'auto' | 'manual',
+            }))
+          }
+        >
+          <FormControlLabel value="auto" control={<Radio />} label="Auto" />
+          <FormControlLabel value="manual" control={<Radio />} label="Manual" />
+        </RadioGroup>
+      </FormControl>
+
+      <Box>
+        <Typography gutterBottom>Posts Per Day: {values.postsPerDay}</Typography>
+        <Slider
+          value={values.postsPerDay}
+          onChange={(_, val) => setValues((v) => ({ ...v, postsPerDay: val as number }))}
+          min={1}
+          max={15}
+          step={1}
+          marks
+          valueLabelDisplay="auto"
+        />
+      </Box>
+
+      <Box>
+        <Typography gutterBottom>Min Interval (hours): {values.minIntervalHours}</Typography>
+        <Slider
+          value={values.minIntervalHours}
+          onChange={(_, val) => setValues((v) => ({ ...v, minIntervalHours: val as number }))}
+          min={1}
+          max={15}
+          step={1}
+          marks
+          valueLabelDisplay="auto"
+        />
+      </Box>
+
+      <FormControl fullWidth>
+        <InputLabel>Preferred Hours Start</InputLabel>
+        <Select
+          value={values.preferredHoursStart}
+          label="Preferred Hours Start"
+          onChange={(e) =>
+            setValues((v) => ({
+              ...v,
+              preferredHoursStart: e.target.value as number,
+            }))
+          }
+        >
+          {Array.from({ length: 24 }, (_, i) => (
+            <MenuItem key={i} value={i}>
+              {i.toString().padStart(2, '0')}:00
+            </MenuItem>
+          ))}
+        </Select>
+      </FormControl>
+
+      <FormControl fullWidth>
+        <InputLabel>Preferred Hours End</InputLabel>
+        <Select
+          value={values.preferredHoursEnd}
+          label="Preferred Hours End"
+          onChange={(e) =>
+            setValues((v) => ({
+              ...v,
+              preferredHoursEnd: e.target.value as number,
+            }))
+          }
+        >
+          {Array.from({ length: 24 }, (_, i) => (
+            <MenuItem key={i + 1} value={i + 1}>
+              {(i + 1).toString().padStart(2, '0')}:00
+            </MenuItem>
+          ))}
+        </Select>
+      </FormControl>
+
+      {Object.keys(errors).length > 0 && (
+        <Alert severity="error">Please fix the errors above.</Alert>
+      )}
+
+      <Button type="submit" variant="contained" size="large" disabled={isLoading}>
+        {isLoading ? 'Saving...' : submitLabel}
+      </Button>
+    </Box>
+  );
+}

--- a/web/src/hooks/useAuth.ts
+++ b/web/src/hooks/useAuth.ts
@@ -1,0 +1,56 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { apiClient } from '../lib/apiClient';
+import { queryKeys } from '../lib/queryKeys';
+
+type User = {
+  id: string;
+  email: string;
+};
+
+type AuthResponse = {
+  data: User;
+};
+
+type MagicLinkResponse = {
+  data: { url: string };
+};
+
+export function useAuth() {
+  const query = useQuery({
+    queryKey: queryKeys.auth.me,
+    queryFn: async () => {
+      const response = await apiClient.get<AuthResponse>('/auth/me');
+      return response.data.data;
+    },
+    retry: false,
+  });
+
+  return {
+    user: query.data ?? null,
+    isLoading: query.isLoading,
+    isAuthenticated: !!query.data,
+    error: query.error,
+  };
+}
+
+export function useLoginMutation() {
+  return useMutation({
+    mutationFn: async (email: string) => {
+      const response = await apiClient.post<MagicLinkResponse>('/auth/magic-link', { email });
+      return response.data.data;
+    },
+  });
+}
+
+export function useLogoutMutation() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async () => {
+      await apiClient.post('/auth/logout');
+    },
+    onSuccess: () => {
+      queryClient.clear();
+    },
+  });
+}

--- a/web/src/hooks/useBot.ts
+++ b/web/src/hooks/useBot.ts
@@ -1,0 +1,96 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { apiClient } from '../lib/apiClient';
+import { queryKeys } from '../lib/queryKeys';
+
+type Bot = {
+  id: string;
+  userId: string;
+  xAccountHandle: string;
+  prompt: string;
+  postMode: string;
+  postsPerDay: number;
+  minIntervalHours: number;
+  preferredHoursStart: number;
+  preferredHoursEnd: number;
+  active: boolean;
+  createdAt: string;
+};
+
+type BotListResponse = {
+  data: Bot[];
+  meta: { page: number; pageSize: number; total: number };
+};
+
+type BotResponse = {
+  data: Bot;
+};
+
+type CreateBotInput = {
+  xAccessToken: string;
+  xAccessSecret: string;
+  xAccountHandle: string;
+  prompt: string;
+  postMode: string;
+  postsPerDay: number;
+  minIntervalHours: number;
+  preferredHoursStart: number;
+  preferredHoursEnd: number;
+};
+
+type UpdateBotInput = {
+  prompt?: string;
+  postMode?: string;
+  postsPerDay?: number;
+  minIntervalHours?: number;
+  preferredHoursStart?: number;
+  preferredHoursEnd?: number;
+  active?: boolean;
+};
+
+export function useBot() {
+  const query = useQuery({
+    queryKey: queryKeys.bots.list,
+    queryFn: async () => {
+      const response = await apiClient.get<BotListResponse>('/bots');
+      return response.data;
+    },
+  });
+
+  const bots = query.data?.data ?? [];
+  const bot = bots.length > 0 ? bots[0] : null;
+
+  return {
+    bot,
+    bots,
+    isLoading: query.isLoading,
+    error: query.error,
+  };
+}
+
+export function useCreateBot() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (input: CreateBotInput) => {
+      const response = await apiClient.post<BotResponse>('/bots', input);
+      return response.data.data;
+    },
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: queryKeys.bots.list });
+    },
+  });
+}
+
+export function useUpdateBot() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({ id, ...input }: UpdateBotInput & { id: string }) => {
+      const response = await apiClient.patch<BotResponse>(`/bots/${id}`, input);
+      return response.data.data;
+    },
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: queryKeys.bots.list });
+    },
+  });
+}

--- a/web/src/lib/apiClient.ts
+++ b/web/src/lib/apiClient.ts
@@ -1,0 +1,6 @@
+import axios from 'axios';
+
+export const apiClient = axios.create({
+  baseURL: '/api',
+  withCredentials: true,
+});

--- a/web/src/lib/queryKeys.ts
+++ b/web/src/lib/queryKeys.ts
@@ -1,0 +1,9 @@
+export const queryKeys = {
+  auth: {
+    me: ['auth', 'me'] as const,
+  },
+  bots: {
+    list: ['bots', 'list'] as const,
+    detail: (id: string) => ['bots', 'detail', id] as const,
+  },
+} as const;

--- a/web/src/pages/DashboardPage.tsx
+++ b/web/src/pages/DashboardPage.tsx
@@ -1,0 +1,177 @@
+import { useState } from 'react';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Card from '@mui/material/Card';
+import CardContent from '@mui/material/CardContent';
+import Chip from '@mui/material/Chip';
+import Container from '@mui/material/Container';
+import Switch from '@mui/material/Switch';
+import Typography from '@mui/material/Typography';
+import CircularProgress from '@mui/material/CircularProgress';
+import Dialog from '@mui/material/Dialog';
+import DialogTitle from '@mui/material/DialogTitle';
+import DialogContent from '@mui/material/DialogContent';
+import AppHeader from '../components/AppHeader';
+import BotSetupForm from '../components/BotSetupForm';
+import { useBot, useUpdateBot } from '../hooks/useBot';
+import { apiClient } from '../lib/apiClient';
+
+export default function DashboardPage() {
+  const { bot, isLoading } = useBot();
+  const updateBot = useUpdateBot();
+  const [editOpen, setEditOpen] = useState(false);
+  const [connectLoading, setConnectLoading] = useState(false);
+
+  const handleToggleActive = () => {
+    if (!bot) return;
+    updateBot.mutate({ id: bot.id, active: !bot.active });
+  };
+
+  const handleConnectX = async () => {
+    if (!bot) return;
+    setConnectLoading(true);
+    try {
+      const response = await apiClient.get<{ data: { url: string } }>(
+        `/auth/x/connect?botId=${bot.id}`,
+      );
+      window.location.href = response.data.data.url;
+    } catch {
+      setConnectLoading(false);
+    }
+  };
+
+  if (isLoading) {
+    return (
+      <>
+        <AppHeader />
+        <Container maxWidth="md" sx={{ mt: 4, textAlign: 'center' }}>
+          <CircularProgress />
+        </Container>
+      </>
+    );
+  }
+
+  if (!bot) {
+    return (
+      <>
+        <AppHeader />
+        <Container maxWidth="md" sx={{ mt: 4 }}>
+          <Box
+            sx={{
+              display: 'flex',
+              flexDirection: 'column',
+              alignItems: 'center',
+              gap: 3,
+              py: 8,
+            }}
+          >
+            <Typography variant="h4">Set up your bot</Typography>
+            <Typography variant="body1" color="text.secondary">
+              You don't have a bot yet. Connect your X account to get started.
+            </Typography>
+            <Typography variant="body2" color="text.secondary">
+              Bot creation requires connecting your X account first via the API.
+            </Typography>
+          </Box>
+        </Container>
+      </>
+    );
+  }
+
+  return (
+    <>
+      <AppHeader />
+      <Container maxWidth="md" sx={{ mt: 4 }}>
+        <Typography variant="h4" gutterBottom>
+          Dashboard
+        </Typography>
+
+        <Card sx={{ mb: 3 }}>
+          <CardContent>
+            <Box
+              sx={{
+                display: 'flex',
+                justifyContent: 'space-between',
+                alignItems: 'center',
+                mb: 2,
+              }}
+            >
+              <Box>
+                <Typography variant="h5">@{bot.xAccountHandle || 'Not connected'}</Typography>
+                <Chip
+                  label={bot.active ? 'Active' : 'Inactive'}
+                  color={bot.active ? 'success' : 'default'}
+                  size="small"
+                  sx={{ mt: 1 }}
+                />
+              </Box>
+              <Switch
+                checked={bot.active}
+                onChange={handleToggleActive}
+                disabled={updateBot.isPending}
+              />
+            </Box>
+
+            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
+              <Typography variant="body2" color="text.secondary">
+                Mode: {bot.postMode} | Posts/day: {bot.postsPerDay} | Min interval:{' '}
+                {bot.minIntervalHours}h
+              </Typography>
+              <Typography variant="body2" color="text.secondary">
+                Active hours: {bot.preferredHoursStart}:00 - {bot.preferredHoursEnd}:00
+              </Typography>
+              <Typography
+                variant="body2"
+                color="text.secondary"
+                sx={{
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                  whiteSpace: 'nowrap',
+                }}
+              >
+                Prompt: {bot.prompt}
+              </Typography>
+            </Box>
+
+            <Box sx={{ display: 'flex', gap: 2, mt: 2 }}>
+              <Button variant="outlined" onClick={handleConnectX} disabled={connectLoading}>
+                {connectLoading ? 'Connecting...' : 'Connect X'}
+              </Button>
+              <Button variant="outlined" onClick={() => setEditOpen(true)}>
+                Edit Config
+              </Button>
+            </Box>
+          </CardContent>
+        </Card>
+
+        <Dialog open={editOpen} onClose={() => setEditOpen(false)} maxWidth="sm" fullWidth>
+          <DialogTitle>Edit Bot Configuration</DialogTitle>
+          <DialogContent>
+            <Box sx={{ pt: 1 }}>
+              <BotSetupForm
+                initialValues={{
+                  prompt: bot.prompt,
+                  postMode: bot.postMode as 'auto' | 'manual',
+                  postsPerDay: bot.postsPerDay,
+                  minIntervalHours: bot.minIntervalHours,
+                  preferredHoursStart: bot.preferredHoursStart,
+                  preferredHoursEnd: bot.preferredHoursEnd,
+                }}
+                onSubmit={(values) => {
+                  updateBot.mutate(
+                    { id: bot.id, ...values },
+                    {
+                      onSuccess: () => setEditOpen(false),
+                    },
+                  );
+                }}
+                isLoading={updateBot.isPending}
+                submitLabel="Update"
+              />
+            </Box>
+          </DialogContent>
+        </Dialog>
+      </Container>
+    </>
+  );
+}

--- a/web/src/pages/LoginPage.tsx
+++ b/web/src/pages/LoginPage.tsx
@@ -1,0 +1,122 @@
+import { useState } from 'react';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Container from '@mui/material/Container';
+import TextField from '@mui/material/TextField';
+import Typography from '@mui/material/Typography';
+import Alert from '@mui/material/Alert';
+import Paper from '@mui/material/Paper';
+import { useLoginMutation } from '../hooks/useAuth';
+
+const ALLOWED_DOMAINS = ['thestartupfactory.tech', 'ehe.ai'];
+
+function validateEmail(email: string): string | null {
+  if (!email) return 'Email is required';
+  const parts = email.split('@');
+  if (parts.length !== 2) return 'Invalid email address';
+  const domain = parts[1];
+  if (!ALLOWED_DOMAINS.includes(domain)) {
+    return `Email must be from: ${ALLOWED_DOMAINS.join(', ')}`;
+  }
+  return null;
+}
+
+export default function LoginPage() {
+  const [email, setEmail] = useState('');
+  const [emailError, setEmailError] = useState<string | null>(null);
+  const [magicLinkUrl, setMagicLinkUrl] = useState<string | null>(null);
+  const loginMutation = useLoginMutation();
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    const error = validateEmail(email);
+    if (error) {
+      setEmailError(error);
+      return;
+    }
+    setEmailError(null);
+    setMagicLinkUrl(null);
+    loginMutation.mutate(email, {
+      onSuccess: (data) => {
+        setMagicLinkUrl(data.url);
+      },
+    });
+  };
+
+  return (
+    <Container maxWidth="sm">
+      <Box
+        sx={{
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          justifyContent: 'center',
+          minHeight: '100vh',
+          gap: 3,
+        }}
+      >
+        <Typography variant="h3" component="h1" fontWeight={700}>
+          X Bot Platform
+        </Typography>
+        <Typography variant="body1" color="text.secondary">
+          Sign in to manage your bots
+        </Typography>
+
+        <Paper sx={{ p: 4, width: '100%' }}>
+          <Box
+            component="form"
+            onSubmit={handleSubmit}
+            sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}
+          >
+            <TextField
+              label="Email"
+              type="email"
+              value={email}
+              onChange={(e) => {
+                setEmail(e.target.value);
+                setEmailError(null);
+              }}
+              error={!!emailError}
+              helperText={emailError}
+              fullWidth
+              autoFocus
+            />
+            <Button
+              type="submit"
+              variant="contained"
+              size="large"
+              disabled={loginMutation.isPending}
+              fullWidth
+            >
+              {loginMutation.isPending ? 'Sending...' : 'Send Magic Link'}
+            </Button>
+          </Box>
+
+          {loginMutation.isError && (
+            <Alert severity="error" sx={{ mt: 2 }}>
+              {loginMutation.error instanceof Error
+                ? loginMutation.error.message
+                : 'Failed to send magic link'}
+            </Alert>
+          )}
+
+          {magicLinkUrl && (
+            <Alert severity="success" sx={{ mt: 2 }}>
+              <Typography variant="body2" sx={{ mb: 1 }}>
+                Magic link generated:
+              </Typography>
+              <Typography
+                variant="body2"
+                component="a"
+                href={magicLinkUrl}
+                sx={{ wordBreak: 'break-all' }}
+              >
+                {magicLinkUrl}
+              </Typography>
+            </Alert>
+          )}
+        </Paper>
+      </Box>
+    </Container>
+  );
+}

--- a/web/src/pages/PostsPage.tsx
+++ b/web/src/pages/PostsPage.tsx
@@ -1,0 +1,19 @@
+import Container from '@mui/material/Container';
+import Typography from '@mui/material/Typography';
+import AppHeader from '../components/AppHeader';
+
+export default function PostsPage() {
+  return (
+    <>
+      <AppHeader />
+      <Container maxWidth="md" sx={{ mt: 4, textAlign: 'center' }}>
+        <Typography variant="h4" gutterBottom>
+          Posts
+        </Typography>
+        <Typography variant="body1" color="text.secondary">
+          Posts page coming soon
+        </Typography>
+      </Container>
+    </>
+  );
+}

--- a/web/src/pages/VerifyPage.tsx
+++ b/web/src/pages/VerifyPage.tsx
@@ -1,0 +1,65 @@
+import { useEffect, useRef } from 'react';
+import Box from '@mui/material/Box';
+import CircularProgress from '@mui/material/CircularProgress';
+import Container from '@mui/material/Container';
+import Typography from '@mui/material/Typography';
+import Alert from '@mui/material/Alert';
+import { apiClient } from '../lib/apiClient';
+
+export default function VerifyPage() {
+  const hasRun = useRef(false);
+  const errorRef = useRef<string | null>(null);
+  const loadingRef = useRef(true);
+
+  useEffect(() => {
+    if (hasRun.current) return;
+    hasRun.current = true;
+
+    const params = new URLSearchParams(window.location.search);
+    const token = params.get('token');
+
+    if (!token) {
+      errorRef.current = 'No verification token provided';
+      loadingRef.current = false;
+      return;
+    }
+
+    apiClient
+      .get(`/auth/verify?token=${encodeURIComponent(token)}`)
+      .then(() => {
+        window.location.href = '/dashboard';
+      })
+      .catch(() => {
+        errorRef.current = 'Verification failed. The link may have expired.';
+        loadingRef.current = false;
+      });
+  }, []);
+
+  // Since the verify endpoint redirects, the browser follows it.
+  // We just show a loading state.
+  return (
+    <Container maxWidth="sm">
+      <Box
+        sx={{
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          justifyContent: 'center',
+          minHeight: '100vh',
+          gap: 2,
+        }}
+      >
+        {errorRef.current ? (
+          <Alert severity="error">{errorRef.current}</Alert>
+        ) : (
+          <>
+            <CircularProgress />
+            <Typography variant="body1" color="text.secondary">
+              Verifying your login...
+            </Typography>
+          </>
+        )}
+      </Box>
+    </Container>
+  );
+}

--- a/web/src/routes/router.tsx
+++ b/web/src/routes/router.tsx
@@ -1,0 +1,96 @@
+import {
+  createRootRoute,
+  createRoute,
+  createRouter,
+  redirect,
+  Outlet,
+} from '@tanstack/react-router';
+import { QueryClient } from '@tanstack/react-query';
+import { apiClient } from '../lib/apiClient';
+import LoginPage from '../pages/LoginPage';
+import VerifyPage from '../pages/VerifyPage';
+import DashboardPage from '../pages/DashboardPage';
+import PostsPage from '../pages/PostsPage';
+
+async function checkAuth(): Promise<boolean> {
+  try {
+    await apiClient.get('/auth/me');
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const rootRoute = createRootRoute({
+  component: Outlet,
+});
+
+const loginRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: '/login',
+  component: LoginPage,
+});
+
+const verifyRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: '/auth/verify',
+  component: VerifyPage,
+});
+
+const dashboardRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: '/dashboard',
+  beforeLoad: async () => {
+    const authenticated = await checkAuth();
+    if (!authenticated) {
+      throw redirect({ to: '/login' });
+    }
+  },
+  component: DashboardPage,
+});
+
+const postsRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: '/posts',
+  beforeLoad: async () => {
+    const authenticated = await checkAuth();
+    if (!authenticated) {
+      throw redirect({ to: '/login' });
+    }
+  },
+  component: PostsPage,
+});
+
+const indexRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: '/',
+  beforeLoad: async () => {
+    const authenticated = await checkAuth();
+    if (authenticated) {
+      throw redirect({ to: '/dashboard' });
+    } else {
+      throw redirect({ to: '/login' });
+    }
+  },
+});
+
+const routeTree = rootRoute.addChildren([
+  indexRoute,
+  loginRoute,
+  verifyRoute,
+  dashboardRoute,
+  postsRoute,
+]);
+
+export function createAppRouter(_queryClient?: QueryClient) {
+  return createRouter({
+    routeTree,
+    defaultPreload: 'intent',
+  });
+}
+
+declare module '@tanstack/react-router' {
+  interface Register {
+    router: ReturnType<typeof createAppRouter>;
+  }
+}


### PR DESCRIPTION
## Summary
- Add X OAuth 1.0a flow (HMAC-SHA1 signing, in-memory request token store with TTL) via new API files: `xOAuthService`, `xOAuthController`, `xOAuthRoutes`
- Add web login page with email domain validation and magic link flow
- Add verify page that handles token verification and redirects to dashboard
- Add dashboard page with bot status card, active toggle, X connect button, and edit config dialog
- Add bot setup form with Zod validation (prompt, post mode, posts/day, interval, preferred hours)
- Add posts page placeholder for Slice 3
- Set up TanStack Router with protected routes (auth check + redirect to /login)
- Add shared hooks (`useAuth`, `useBot`) and API client with TanStack Query

## Test plan
- [ ] Verify web build succeeds (`npm run build --workspace=web`)
- [ ] Verify login page renders with email input and domain validation
- [ ] Verify magic link flow shows URL on success
- [ ] Verify protected routes redirect to /login when unauthenticated
- [ ] Verify dashboard shows bot card when bot exists, CTA when not
- [ ] Verify bot config edit form validates and submits correctly
- [ ] Verify X OAuth connect initiates redirect
- [ ] Verify logout clears session and redirects to login

Closes #3, Closes #4, Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)