### PR TITLE
feat: AI content generation service using Claude API

### DIFF
--- a/api/src/services/aiService.ts
+++ b/api/src/services/aiService.ts
@@ -1,0 +1,61 @@
+import Anthropic from '@anthropic-ai/sdk';
+
+type GenerateTweetResult = {
+  content: string;
+  success: boolean;
+  error?: string;
+};
+
+const SYSTEM_PROMPT = `You are a social media expert and skilled copywriter. Given a user's prompt, research and consider relevant topics, trends, and context, then draft a single tweet.
+
+Rules:
+- The tweet MUST be under 280 characters
+- Make it engaging, authentic-sounding, and conversational
+- Do not use hashtags excessively — one or two at most
+- Do not include quotation marks around the tweet
+- Output ONLY the tweet text, nothing else`;
+
+async function callClaude(client: Anthropic, prompt: string): Promise<string> {
+  const response = await client.messages.create({
+    model: 'claude-sonnet-4-20250514',
+    max_tokens: 300,
+    system: SYSTEM_PROMPT,
+    messages: [{ role: 'user', content: prompt }],
+  });
+
+  const block = response.content[0];
+  if (block.type === 'text') {
+    return block.text.trim();
+  }
+
+  throw new Error('Unexpected response format from Claude API');
+}
+
+export async function generateTweet(prompt: string): Promise<GenerateTweetResult> {
+  const apiKey = process.env.ANTHROPIC_API_KEY;
+
+  if (!apiKey) {
+    return {
+      content: 'AI service not configured \u2014 set ANTHROPIC_API_KEY',
+      success: false,
+      error: 'ANTHROPIC_API_KEY not set',
+    };
+  }
+
+  const client = new Anthropic({ apiKey });
+
+  // First attempt
+  try {
+    const content = await callClaude(client, prompt);
+    return { content, success: true };
+  } catch {
+    // Retry once on failure
+    try {
+      const content = await callClaude(client, prompt);
+      return { content, success: true };
+    } catch (retryErr: unknown) {
+      const message = retryErr instanceof Error ? retryErr.message : String(retryErr);
+      return { content: '', success: false, error: message };
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Add `generateTweet()` function in `api/src/services/aiService.ts` using the Anthropic SDK (`claude-sonnet-4-20250514` model)
- System prompt instructs the AI to act as a social media expert and draft a single tweet under 280 characters
- Includes retry-once logic on API failure, returns structured `{ content, success, error? }` response
- Gracefully handles missing `ANTHROPIC_API_KEY` with a placeholder response

Closes #9

## Test plan
- [ ] Verify TypeScript compiles with `npx tsc -p api/tsconfig.json --noEmit`
- [ ] Verify ESLint passes on `api/src/services/`
- [ ] Set `ANTHROPIC_API_KEY` and call `generateTweet("write about AI trends")` — confirm a tweet under 280 chars is returned
- [ ] Unset `ANTHROPIC_API_KEY` and confirm placeholder error response is returned
- [ ] Simulate API error to confirm retry logic and error response

🤖 Generated with [Claude Code](https://claude.com/claude-code)