### PR TITLE
feat: job scheduling engine, worker, and stale lock recovery

### DIFF
--- a/api/src/repositories/jobRepository.ts
+++ b/api/src/repositories/jobRepository.ts
@@ -6,6 +6,18 @@ type TransactionClient = Omit<
   '$connect' | '$disconnect' | '$on' | '$transaction' | '$use' | '$extends'
 >;
 
+type JobRow = {
+  id: string;
+  botId: string;
+  status: string;
+  lockToken: string | null;
+  lockedAt: Date | null;
+  scheduledAt: Date;
+  startedAt: Date | null;
+  completedAt: Date | null;
+  createdAt: Date;
+};
+
 export const jobRepository = {
   async createInTransaction(
     tx: TransactionClient,
@@ -26,6 +38,87 @@ export const jobRepository = {
         botId: data.botId,
         scheduledAt: data.scheduledAt,
         status: data.status || 'pending',
+      },
+    });
+  },
+
+  async findPendingJobs(limit = 10) {
+    return prisma.job.findMany({
+      where: {
+        status: 'pending',
+        scheduledAt: { lte: new Date() },
+        bot: { active: true },
+      },
+      include: { bot: true },
+      take: limit,
+      orderBy: { scheduledAt: 'asc' },
+    });
+  },
+
+  /**
+   * Atomic claim using SELECT ... FOR UPDATE SKIP LOCKED.
+   * Returns the claimed job or null if no job was available.
+   */
+  async claimJob(jobId: string, lockToken: string): Promise<JobRow | null> {
+    const now = new Date();
+    const result = await prisma.$queryRaw<JobRow[]>`
+      UPDATE "Job"
+      SET status = 'locked',
+          "lockToken" = ${lockToken}::uuid,
+          "lockedAt" = ${now},
+          "startedAt" = ${now}
+      WHERE id = (
+        SELECT id FROM "Job"
+        WHERE id = ${jobId}::uuid
+          AND status = 'pending'
+        FOR UPDATE SKIP LOCKED
+      )
+      RETURNING *
+    `;
+    return result.length > 0 ? result[0] : null;
+  },
+
+  async markCompleted(jobId: string) {
+    return prisma.job.update({
+      where: { id: jobId },
+      data: {
+        status: 'completed',
+        completedAt: new Date(),
+      },
+    });
+  },
+
+  async markFailed(jobId: string) {
+    return prisma.job.update({
+      where: { id: jobId },
+      data: {
+        status: 'failed',
+        completedAt: new Date(),
+      },
+    });
+  },
+
+  async findStaleLockedJobs(staleMinutes = 10) {
+    const cutoff = new Date(Date.now() - staleMinutes * 60 * 1000);
+    return prisma.job.findMany({
+      where: {
+        status: 'locked',
+        lockedAt: { lt: cutoff },
+      },
+    });
+  },
+
+  async resetStaleLocks(staleMinutes = 10) {
+    const cutoff = new Date(Date.now() - staleMinutes * 60 * 1000);
+    return prisma.job.updateMany({
+      where: {
+        status: 'locked',
+        lockedAt: { lt: cutoff },
+      },
+      data: {
+        status: 'pending',
+        lockToken: null,
+        lockedAt: null,
       },
     });
   },

--- a/api/src/repositories/postRepository.ts
+++ b/api/src/repositories/postRepository.ts
@@ -1,0 +1,43 @@
+import { prisma } from '../utils/prisma.js';
+
+export const postRepository = {
+  async create(data: {
+    botId: string;
+    jobId: string;
+    content: string;
+    status: string;
+    scheduledAt?: Date | null;
+  }) {
+    return prisma.post.create({
+      data: {
+        botId: data.botId,
+        jobId: data.jobId,
+        content: data.content,
+        status: data.status,
+        scheduledAt: data.scheduledAt ?? null,
+      },
+    });
+  },
+
+  async findByStatus(status: string, limit = 50) {
+    return prisma.post.findMany({
+      where: { status },
+      take: limit,
+      orderBy: { scheduledAt: 'asc' },
+    });
+  },
+
+  async updateStatus(
+    id: string,
+    status: string,
+    extra?: { publishedAt?: Date; scheduledAt?: Date },
+  ) {
+    return prisma.post.update({
+      where: { id },
+      data: {
+        status,
+        ...extra,
+      },
+    });
+  },
+};

--- a/api/src/services/scheduler.ts
+++ b/api/src/services/scheduler.ts
@@ -1,0 +1,65 @@
+export type ScheduleConfig = {
+  postsPerDay: number;
+  minIntervalHours: number;
+  preferredHoursStart: number;
+  preferredHoursEnd: number;
+};
+
+export function computeNextScheduledAt(config: ScheduleConfig, completedAt: Date): Date {
+  const { postsPerDay, minIntervalHours, preferredHoursStart, preferredHoursEnd } = config;
+
+  // Base interval in hours
+  const baseIntervalHours = 24 / postsPerDay;
+
+  // Apply ±10% random jitter
+  const jitterFactor = 0.9 + Math.random() * 0.2;
+  let intervalHours = baseIntervalHours * jitterFactor;
+
+  // Floor at minIntervalHours
+  if (intervalHours < minIntervalHours) {
+    intervalHours = minIntervalHours;
+  }
+
+  const next = new Date(completedAt.getTime() + intervalHours * 60 * 60 * 1000);
+
+  // No window constraint if start=0 and end=24
+  if (preferredHoursStart === 0 && preferredHoursEnd === 24) {
+    return next;
+  }
+
+  const windowSize = preferredHoursEnd - preferredHoursStart;
+
+  // If window too narrow (less than minIntervalHours), we need to handle carefully
+  if (windowSize <= 0) {
+    // Invalid window — skip to next day's window start
+    return advanceToWindowStart(next, preferredHoursStart, 1);
+  }
+
+  const nextHour = next.getUTCHours() + next.getUTCMinutes() / 60;
+
+  if (nextHour >= preferredHoursStart && nextHour < preferredHoursEnd) {
+    // Already within the preferred window
+    return next;
+  }
+
+  if (nextHour < preferredHoursStart) {
+    // Before window — advance to window start same day
+    return setUtcHour(next, preferredHoursStart);
+  }
+
+  // After window — skip to next day's window start
+  return advanceToWindowStart(next, preferredHoursStart, 1);
+}
+
+function setUtcHour(date: Date, hour: number): Date {
+  const result = new Date(date);
+  result.setUTCHours(Math.floor(hour), Math.round((hour % 1) * 60), 0, 0);
+  return result;
+}
+
+function advanceToWindowStart(date: Date, windowStartHour: number, daysToAdd: number): Date {
+  const result = new Date(date);
+  result.setUTCDate(result.getUTCDate() + daysToAdd);
+  result.setUTCHours(Math.floor(windowStartHour), Math.round((windowStartHour % 1) * 60), 0, 0);
+  return result;
+}

--- a/api/src/worker/index.ts
+++ b/api/src/worker/index.ts
@@ -1,0 +1,21 @@
+import * as jobWorker from './jobWorker.js';
+import * as staleLockRecovery from './staleLockRecovery.js';
+
+function shutdown(): void {
+  console.log('[worker] Shutting down gracefully...');
+  jobWorker.stop();
+  staleLockRecovery.stop();
+  // Post publisher placeholder — will be added later
+  process.exit(0);
+}
+
+process.on('SIGTERM', shutdown);
+process.on('SIGINT', shutdown);
+
+console.log('[worker] Starting worker processes...');
+
+jobWorker.start();
+staleLockRecovery.start();
+// Post publisher placeholder — will start here when implemented
+
+console.log('[worker] All worker processes started');

--- a/api/src/worker/jobWorker.ts
+++ b/api/src/worker/jobWorker.ts
@@ -1,0 +1,95 @@
+import { v4 as uuidv4 } from 'uuid';
+import { jobRepository } from '../repositories/jobRepository.js';
+import { postRepository } from '../repositories/postRepository.js';
+import { generateTweet } from '../services/aiService.js';
+import { computeNextScheduledAt } from '../services/scheduler.js';
+
+const POLL_INTERVAL_MS = parseInt(process.env.WORKER_POLL_INTERVAL_MS || '30000', 10);
+
+let intervalHandle: ReturnType<typeof setInterval> | null = null;
+let running = false;
+
+async function processJobs(): Promise<void> {
+  if (running) return;
+  running = true;
+
+  try {
+    const pendingJobs = await jobRepository.findPendingJobs(10);
+
+    for (const job of pendingJobs) {
+      const lockToken = uuidv4();
+      const claimed = await jobRepository.claimJob(job.id, lockToken);
+
+      if (!claimed) {
+        continue;
+      }
+
+      try {
+        const bot = job.bot;
+        const result = await generateTweet(bot.prompt);
+
+        if (!result.success) {
+          console.error(`[jobWorker] AI generation failed for job ${job.id}: ${result.error}`);
+          await jobRepository.markFailed(job.id);
+          continue;
+        }
+
+        const postStatus = bot.postMode === 'auto' ? 'scheduled' : 'draft';
+        const scheduledAt = bot.postMode === 'auto' ? new Date() : null;
+
+        await postRepository.create({
+          botId: bot.id,
+          jobId: job.id,
+          content: result.content,
+          status: postStatus,
+          scheduledAt,
+        });
+
+        await jobRepository.markCompleted(job.id);
+
+        // Schedule next job
+        const nextScheduledAt = computeNextScheduledAt(
+          {
+            postsPerDay: bot.postsPerDay,
+            minIntervalHours: bot.minIntervalHours,
+            preferredHoursStart: bot.preferredHoursStart,
+            preferredHoursEnd: bot.preferredHoursEnd,
+          },
+          new Date(),
+        );
+
+        await jobRepository.create({
+          botId: bot.id,
+          scheduledAt: nextScheduledAt,
+          status: 'pending',
+        });
+
+        console.log(
+          `[jobWorker] Job ${job.id} completed. Next job scheduled at ${nextScheduledAt.toISOString()}`,
+        );
+      } catch (err) {
+        console.error(`[jobWorker] Error processing job ${job.id}:`, err);
+        await jobRepository.markFailed(job.id);
+      }
+    }
+  } catch (err) {
+    console.error('[jobWorker] Error polling for jobs:', err);
+  } finally {
+    running = false;
+  }
+}
+
+export function start(): void {
+  console.log(`[jobWorker] Starting with poll interval ${POLL_INTERVAL_MS}ms`);
+  // Run immediately on start
+  void processJobs();
+  intervalHandle = setInterval(() => void processJobs(), POLL_INTERVAL_MS);
+}
+
+export function stop(): void {
+  if (intervalHandle) {
+    clearInterval(intervalHandle);
+    intervalHandle = null;
+  }
+  console.log('[jobWorker] Stopped');
+}

--- a/api/src/worker/staleLockRecovery.ts
+++ b/api/src/worker/staleLockRecovery.ts
@@ -1,0 +1,41 @@
+import { jobRepository } from '../repositories/jobRepository.js';
+
+const RECOVERY_INTERVAL_MS = 5 * 60 * 1000; // 5 minutes
+const STALE_THRESHOLD_MINUTES = 10;
+
+let intervalHandle: ReturnType<typeof setInterval> | null = null;
+
+async function recoverStaleLocks(): Promise<void> {
+  try {
+    const staleJobs = await jobRepository.findStaleLockedJobs(STALE_THRESHOLD_MINUTES);
+
+    if (staleJobs.length === 0) {
+      return;
+    }
+
+    console.log(
+      `[staleLockRecovery] Found ${staleJobs.length} stale locked jobs: ${staleJobs.map((j: { id: string }) => j.id).join(', ')}`,
+    );
+
+    const result = await jobRepository.resetStaleLocks(STALE_THRESHOLD_MINUTES);
+
+    console.log(`[staleLockRecovery] Recovered ${result.count} stale locked jobs`);
+  } catch (err) {
+    console.error('[staleLockRecovery] Error recovering stale locks:', err);
+  }
+}
+
+export function start(): void {
+  console.log('[staleLockRecovery] Starting stale lock recovery');
+  // Run immediately on start
+  void recoverStaleLocks();
+  intervalHandle = setInterval(() => void recoverStaleLocks(), RECOVERY_INTERVAL_MS);
+}
+
+export function stop(): void {
+  if (intervalHandle) {
+    clearInterval(intervalHandle);
+    intervalHandle = null;
+  }
+  console.log('[staleLockRecovery] Stopped');
+}


### PR DESCRIPTION
## Summary
- **Scheduler** (`api/src/services/scheduler.ts`): `computeNextScheduledAt` computes next job time based on postsPerDay, minIntervalHours, random jitter, and preferred hours window
- **Job Worker** (`api/src/worker/jobWorker.ts`): Polls pending jobs, claims atomically with `SELECT ... FOR UPDATE SKIP LOCKED`, calls AI service stub, creates posts, schedules next job
- **Stale Lock Recovery** (`api/src/worker/staleLockRecovery.ts`): Recovers jobs locked for >10 minutes back to pending status, runs every 5 minutes
- **Worker entry point** (`api/src/worker/index.ts`): Starts all worker processes with graceful SIGTERM/SIGINT shutdown
- **AI Service stub** (`api/src/services/aiService.ts`): Placeholder returning hardcoded tweet, to be replaced in #9
- **Post Repository** (`api/src/repositories/postRepository.ts`): CRUD for posts (create, findByStatus, updateStatus)
- **Job Repository** updates: Added findPendingJobs, claimJob (raw SQL), markCompleted, markFailed, findStaleLockedJobs, resetStaleLocks

## Test plan
- [ ] Verify `computeNextScheduledAt` respects interval, jitter, minIntervalHours, and preferred window
- [ ] Verify worker polls and claims jobs atomically
- [ ] Verify stale lock recovery resets old locked jobs
- [ ] Verify graceful shutdown on SIGTERM/SIGINT
- [ ] `npx tsc -p api/tsconfig.json --noEmit` passes with zero errors

Closes #7
Closes #8
Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)