### PR TITLE
feat: post queue UI with tabs, inline edit, rating, and status actions

### DIFF
--- a/web/src/components/AppHeader.tsx
+++ b/web/src/components/AppHeader.tsx
@@ -3,6 +3,7 @@ import Toolbar from '@mui/material/Toolbar';
 import Typography from '@mui/material/Typography';
 import Button from '@mui/material/Button';
 import Box from '@mui/material/Box';
+import { Link } from '@tanstack/react-router';
 import { useAuth, useLogoutMutation } from '../hooks/useAuth';
 
 export default function AppHeader() {
@@ -20,16 +21,26 @@ export default function AppHeader() {
   return (
     <AppBar position="static">
       <Toolbar>
-        <Typography variant="h6" component="div" sx={{ flexGrow: 1 }}>
+        <Typography variant="h6" component="div" sx={{ mr: 3 }}>
           X Bot Platform
         </Typography>
         {user && (
-          <Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
-            <Typography variant="body2">{user.email}</Typography>
-            <Button color="inherit" onClick={handleLogout} disabled={logoutMutation.isPending}>
-              Logout
-            </Button>
-          </Box>
+          <>
+            <Box sx={{ display: 'flex', gap: 1, flexGrow: 1 }}>
+              <Button color="inherit" component={Link} to="/dashboard">
+                Dashboard
+              </Button>
+              <Button color="inherit" component={Link} to="/posts">
+                Posts
+              </Button>
+            </Box>
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
+              <Typography variant="body2">{user.email}</Typography>
+              <Button color="inherit" onClick={handleLogout} disabled={logoutMutation.isPending}>
+                Logout
+              </Button>
+            </Box>
+          </>
         )}
       </Toolbar>
     </AppBar>

--- a/web/src/components/PostCard.tsx
+++ b/web/src/components/PostCard.tsx
@@ -1,0 +1,171 @@
+import { useState } from 'react';
+import Box from '@mui/material/Box';
+import Card from '@mui/material/Card';
+import CardContent from '@mui/material/CardContent';
+import Chip from '@mui/material/Chip';
+import Typography from '@mui/material/Typography';
+import TextField from '@mui/material/TextField';
+import Button from '@mui/material/Button';
+import Rating from '@mui/material/Rating';
+import type { Post, PostStatus } from '../hooks/usePosts';
+import { useUpdatePost } from '../hooks/usePosts';
+
+const statusColors: Record<PostStatus, 'default' | 'info' | 'success' | 'error'> = {
+  draft: 'default',
+  scheduled: 'info',
+  published: 'success',
+  discarded: 'error',
+};
+
+function formatDate(dateStr: string | null): string {
+  if (!dateStr) return '';
+  return new Date(dateStr).toLocaleString();
+}
+
+type PostCardProps = {
+  post: Post;
+};
+
+export default function PostCard({ post }: PostCardProps) {
+  const [isEditing, setIsEditing] = useState(false);
+  const [editContent, setEditContent] = useState(post.content);
+  const updatePost = useUpdatePost();
+
+  const handleSave = () => {
+    updatePost.mutate(
+      { id: post.id, content: editContent },
+      {
+        onSuccess: () => {
+          setIsEditing(false);
+        },
+      },
+    );
+  };
+
+  const handleCancel = () => {
+    setEditContent(post.content);
+    setIsEditing(false);
+  };
+
+  const handleSchedule = () => {
+    updatePost.mutate({ id: post.id, status: 'scheduled' });
+  };
+
+  const handleDiscard = () => {
+    updatePost.mutate({ id: post.id, status: 'discarded' });
+  };
+
+  const handleRatingChange = (_event: React.SyntheticEvent, value: number | null) => {
+    updatePost.mutate({ id: post.id, rating: value });
+  };
+
+  const ratingEnabled =
+    post.status === 'draft' || post.status === 'scheduled' || post.status === 'published';
+
+  return (
+    <Card sx={{ mb: 2 }}>
+      <CardContent>
+        <Box
+          sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', mb: 1 }}
+        >
+          <Chip label={post.status} color={statusColors[post.status]} size="small" />
+          <Typography variant="caption" color="text.secondary">
+            {formatDate(post.createdAt)}
+          </Typography>
+        </Box>
+
+        {isEditing ? (
+          <Box sx={{ mb: 2 }}>
+            <TextField
+              fullWidth
+              multiline
+              minRows={3}
+              value={editContent}
+              onChange={(e) => setEditContent(e.target.value)}
+              disabled={updatePost.isPending}
+              sx={{ mb: 1 }}
+            />
+            <Box sx={{ display: 'flex', gap: 1 }}>
+              <Button
+                size="small"
+                variant="contained"
+                onClick={handleSave}
+                disabled={updatePost.isPending}
+              >
+                Save
+              </Button>
+              <Button
+                size="small"
+                variant="outlined"
+                onClick={handleCancel}
+                disabled={updatePost.isPending}
+              >
+                Cancel
+              </Button>
+            </Box>
+          </Box>
+        ) : (
+          <Typography variant="body1" sx={{ mb: 2, whiteSpace: 'pre-wrap' }}>
+            {post.content}
+          </Typography>
+        )}
+
+        {post.scheduledAt && (
+          <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mb: 0.5 }}>
+            Scheduled: {formatDate(post.scheduledAt)}
+          </Typography>
+        )}
+        {post.publishedAt && (
+          <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mb: 0.5 }}>
+            Published: {formatDate(post.publishedAt)}
+          </Typography>
+        )}
+
+        <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mt: 1 }}>
+          <Rating
+            value={post.rating}
+            onChange={handleRatingChange}
+            disabled={!ratingEnabled || updatePost.isPending}
+            size="small"
+          />
+
+          <Box sx={{ display: 'flex', gap: 1 }}>
+            {post.status === 'draft' && !isEditing && (
+              <>
+                <Button size="small" variant="outlined" onClick={() => setIsEditing(true)}>
+                  Edit
+                </Button>
+                <Button
+                  size="small"
+                  variant="contained"
+                  onClick={handleSchedule}
+                  disabled={updatePost.isPending}
+                >
+                  Schedule
+                </Button>
+                <Button
+                  size="small"
+                  color="error"
+                  onClick={handleDiscard}
+                  disabled={updatePost.isPending}
+                >
+                  Discard
+                </Button>
+              </>
+            )}
+            {post.status === 'scheduled' && (
+              <Button
+                size="small"
+                color="error"
+                onClick={handleDiscard}
+                disabled={updatePost.isPending}
+              >
+                Discard
+              </Button>
+            )}
+          </Box>
+        </Box>
+      </CardContent>
+    </Card>
+  );
+}

--- a/web/src/hooks/usePosts.ts
+++ b/web/src/hooks/usePosts.ts
@@ -1,0 +1,63 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { apiClient } from '../lib/apiClient';
+import { queryKeys } from '../lib/queryKeys';
+
+export type PostStatus = 'draft' | 'scheduled' | 'published' | 'discarded';
+
+export type Post = {
+  id: string;
+  botId: string;
+  content: string;
+  status: PostStatus;
+  rating: number | null;
+  scheduledAt: string | null;
+  publishedAt: string | null;
+  createdAt: string;
+  updatedAt: string;
+};
+
+type PostListResponse = {
+  data: Post[];
+  meta: { page: number; pageSize: number; total: number };
+};
+
+type PostResponse = {
+  data: Post;
+};
+
+type UpdatePostInput = {
+  id: string;
+  content?: string;
+  status?: PostStatus;
+  rating?: number | null;
+};
+
+export function usePosts(status?: string, page = 1, pageSize = 10) {
+  return useQuery({
+    queryKey: queryKeys.posts.list(status, page),
+    queryFn: async () => {
+      const params: Record<string, string | number> = { page, pageSize };
+      if (status) {
+        params.status = status;
+      }
+      const response = await apiClient.get<PostListResponse>('/posts', {
+        params,
+      });
+      return response.data;
+    },
+  });
+}
+
+export function useUpdatePost() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({ id, ...input }: UpdatePostInput) => {
+      const response = await apiClient.patch<PostResponse>(`/posts/${id}`, input);
+      return response.data.data;
+    },
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: queryKeys.posts.all });
+    },
+  });
+}

--- a/web/src/lib/queryKeys.ts
+++ b/web/src/lib/queryKeys.ts
@@ -6,4 +6,9 @@ export const queryKeys = {
     list: ['bots', 'list'] as const,
     detail: (id: string) => ['bots', 'detail', id] as const,
   },
+  posts: {
+    list: (status?: string, page?: number) =>
+      ['posts', 'list', status ?? 'all', page ?? 1] as const,
+    all: ['posts'] as const,
+  },
 } as const;

--- a/web/src/pages/PostsPage.tsx
+++ b/web/src/pages/PostsPage.tsx
@@ -1,18 +1,107 @@
+import { useState } from 'react';
 import Container from '@mui/material/Container';
 import Typography from '@mui/material/Typography';
+import Tabs from '@mui/material/Tabs';
+import Tab from '@mui/material/Tab';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Skeleton from '@mui/material/Skeleton';
 import AppHeader from '../components/AppHeader';
+import PostCard from '../components/PostCard';
+import { usePosts } from '../hooks/usePosts';
+
+const TAB_CONFIG = [
+  { label: 'All', status: undefined, emptyMessage: 'No posts yet' },
+  { label: 'Drafts', status: 'draft', emptyMessage: 'No drafts yet' },
+  {
+    label: 'Scheduled',
+    status: 'scheduled',
+    emptyMessage: 'No scheduled posts',
+  },
+  {
+    label: 'Published',
+    status: 'published',
+    emptyMessage: 'No published posts',
+  },
+  {
+    label: 'Discarded',
+    status: 'discarded',
+    emptyMessage: 'No discarded posts',
+  },
+] as const;
 
 export default function PostsPage() {
+  const [tabIndex, setTabIndex] = useState(0);
+  const [page, setPage] = useState(1);
+
+  const currentTab = TAB_CONFIG[tabIndex];
+  const { data, isLoading } = usePosts(currentTab.status, page);
+
+  const posts = data?.data ?? [];
+  const meta = data?.meta;
+  const hasMore = meta ? meta.page * meta.pageSize < meta.total : false;
+
+  const handleTabChange = (_event: React.SyntheticEvent, newValue: number) => {
+    setTabIndex(newValue);
+    setPage(1);
+  };
+
+  const handleLoadMore = () => {
+    setPage((prev) => prev + 1);
+  };
+
   return (
     <>
       <AppHeader />
-      <Container maxWidth="md" sx={{ mt: 4, textAlign: 'center' }}>
+      <Container maxWidth="md" sx={{ mt: 4 }}>
         <Typography variant="h4" gutterBottom>
           Posts
         </Typography>
-        <Typography variant="body1" color="text.secondary">
-          Posts page coming soon
-        </Typography>
+
+        <Box sx={{ borderBottom: 1, borderColor: 'divider', mb: 3 }}>
+          <Tabs
+            value={tabIndex}
+            onChange={handleTabChange}
+            variant="scrollable"
+            scrollButtons="auto"
+          >
+            {TAB_CONFIG.map((tab) => (
+              <Tab key={tab.label} label={tab.label} />
+            ))}
+          </Tabs>
+        </Box>
+
+        {isLoading ? (
+          <Box>
+            {[1, 2, 3].map((i) => (
+              <Skeleton
+                key={i}
+                variant="rectangular"
+                height={160}
+                sx={{ mb: 2, borderRadius: 2 }}
+              />
+            ))}
+          </Box>
+        ) : posts.length === 0 ? (
+          <Box sx={{ textAlign: 'center', py: 6 }}>
+            <Typography variant="body1" color="text.secondary">
+              {currentTab.emptyMessage}
+            </Typography>
+          </Box>
+        ) : (
+          <>
+            {posts.map((post) => (
+              <PostCard key={post.id} post={post} />
+            ))}
+            {hasMore && (
+              <Box sx={{ textAlign: 'center', mt: 2, mb: 4 }}>
+                <Button variant="outlined" onClick={handleLoadMore}>
+                  Load more
+                </Button>
+              </Box>
+            )}
+          </>
+        )}
       </Container>
     </>
   );


### PR DESCRIPTION
## Summary
- Add full post management page with tabbed filtering (All, Drafts, Scheduled, Published, Discarded) and pagination
- Create `PostCard` component with inline editing, star rating, and status-based action buttons (Schedule, Discard, Edit)
- Add `usePosts` and `useUpdatePost` hooks using TanStack Query with proper cache invalidation
- Add Dashboard and Posts navigation links to AppHeader

## Test plan
- [ ] Verify tabs filter posts by status correctly
- [ ] Test inline edit mode for draft posts (Save/Cancel)
- [ ] Test star rating on draft/scheduled/published posts (disabled on discarded)
- [ ] Test Schedule and Discard actions update post status
- [ ] Verify empty states display per tab
- [ ] Verify loading skeletons appear during fetch
- [ ] Test "Load more" pagination
- [ ] Verify responsive layout at 360px, 768px, 1280px

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)