### PR TITLE
feat: post management API and X post publisher

### DIFF
--- a/api/src/controllers/postController.ts
+++ b/api/src/controllers/postController.ts
@@ -1,0 +1,55 @@
+import { Request, Response, NextFunction } from 'express';
+import { z } from 'zod';
+import { postService } from '../services/postService.js';
+import { paginationSchema, uuidSchema } from '../utils/validation.js';
+
+const postListQuerySchema = paginationSchema.extend({
+  status: z.string().optional(),
+});
+
+const postIdParamSchema = z.object({
+  id: uuidSchema,
+});
+
+const updatePostSchema = z.object({
+  content: z.string().min(1, 'Content must not be empty').optional(),
+  rating: z.number().int().min(1).max(5).nullable().optional(),
+  status: z.enum(['scheduled', 'discarded']).optional(),
+  scheduledAt: z.string().datetime().nullable().optional(),
+});
+
+export const postController = {
+  async list(req: Request, res: Response, next: NextFunction): Promise<void> {
+    try {
+      const userId = req.userId!;
+      const { page, pageSize, status } = postListQuerySchema.parse(req.query);
+      const { posts, total } = await postService.listPosts(userId, {
+        status,
+        page,
+        pageSize,
+      });
+
+      res.status(200).json({
+        data: posts,
+        meta: { page, pageSize, total },
+      });
+    } catch (err) {
+      next(err);
+    }
+  },
+
+  async update(req: Request, res: Response, next: NextFunction): Promise<void> {
+    try {
+      const userId = req.userId!;
+      const { id } = postIdParamSchema.parse(req.params);
+      const body = updatePostSchema.parse(req.body);
+      const post = await postService.updatePost(id, userId, body);
+
+      res.status(200).json({
+        data: post,
+      });
+    } catch (err) {
+      next(err);
+    }
+  },
+};

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -10,6 +10,7 @@ import healthRoutes from './routes/healthRoutes.js';
 import authRoutes from './routes/authRoutes.js';
 import botRoutes from './routes/botRoutes.js';
 import xOAuthRoutes from './routes/xOAuthRoutes.js';
+import postRoutes from './routes/postRoutes.js';
 
 const app = express();
 
@@ -25,6 +26,7 @@ app.use('/api/health', healthRoutes);
 app.use('/api/auth', authRoutes);
 app.use('/api/bots', botRoutes);
 app.use('/api/auth/x', xOAuthRoutes);
+app.use('/api/posts', postRoutes);
 
 // 404 handler for unknown routes
 app.use(notFoundHandler);

--- a/api/src/repositories/postRepository.ts
+++ b/api/src/repositories/postRepository.ts
@@ -19,11 +19,70 @@ export const postRepository = {
     });
   },
 
+  async findById(id: string) {
+    return prisma.post.findUnique({
+      where: { id },
+      include: { bot: true },
+    });
+  },
+
+  async findByBotIds(
+    botIds: string[],
+    options: { status?: string; page: number; pageSize: number },
+  ) {
+    const where: { botId: { in: string[] }; status?: string } = {
+      botId: { in: botIds },
+    };
+    if (options.status) {
+      where.status = options.status;
+    }
+
+    const [posts, total] = await Promise.all([
+      prisma.post.findMany({
+        where,
+        skip: (options.page - 1) * options.pageSize,
+        take: options.pageSize,
+        orderBy: { createdAt: 'desc' },
+      }),
+      prisma.post.count({ where }),
+    ]);
+
+    return { posts, total };
+  },
+
   async findByStatus(status: string, limit = 50) {
     return prisma.post.findMany({
       where: { status },
       take: limit,
       orderBy: { scheduledAt: 'asc' },
+    });
+  },
+
+  async findScheduledReady(limit = 50) {
+    return prisma.post.findMany({
+      where: {
+        status: 'scheduled',
+        scheduledAt: { lte: new Date() },
+      },
+      take: limit,
+      orderBy: { scheduledAt: 'asc' },
+      include: { bot: true },
+    });
+  },
+
+  async update(
+    id: string,
+    data: {
+      content?: string;
+      status?: string;
+      rating?: number | null;
+      scheduledAt?: Date | null;
+      publishedAt?: Date | null;
+    },
+  ) {
+    return prisma.post.update({
+      where: { id },
+      data,
     });
   },
 

--- a/api/src/routes/postRoutes.ts
+++ b/api/src/routes/postRoutes.ts
@@ -1,0 +1,13 @@
+import { Router } from 'express';
+import { postController } from '../controllers/postController.js';
+import { authMiddleware } from '../middleware/auth.js';
+
+const router = Router();
+
+// All post routes require authentication
+router.use(authMiddleware);
+
+router.get('/', postController.list);
+router.patch('/:id', postController.update);
+
+export default router;

--- a/api/src/services/postService.ts
+++ b/api/src/services/postService.ts
@@ -1,0 +1,97 @@
+import { botRepository } from '../repositories/botRepository.js';
+import { postRepository } from '../repositories/postRepository.js';
+import { NotFoundError, ForbiddenError, ValidationError } from '../utils/errors.js';
+
+type UpdatePostInput = {
+  content?: string;
+  rating?: number | null;
+  status?: 'scheduled' | 'discarded';
+  scheduledAt?: string | null;
+};
+
+export const postService = {
+  async listPosts(userId: string, options: { status?: string; page: number; pageSize: number }) {
+    const { bots } = await botRepository.findByUserId(userId, 1, 1000);
+    const botIds = bots.map((b: { id: string }) => b.id);
+
+    if (botIds.length === 0) {
+      return { posts: [], total: 0 };
+    }
+
+    return postRepository.findByBotIds(botIds, options);
+  },
+
+  async updatePost(postId: string, userId: string, input: UpdatePostInput) {
+    const post = await postRepository.findById(postId);
+    if (!post) {
+      throw new NotFoundError('Post not found');
+    }
+    if (post.bot.userId !== userId) {
+      throw new ForbiddenError('You do not have access to this post');
+    }
+
+    // Validate status transitions
+    if (post.status === 'published') {
+      throw new ForbiddenError('Cannot modify a published post');
+    }
+    if (post.status === 'discarded') {
+      throw new ForbiddenError('Cannot modify a discarded post');
+    }
+
+    // Validate content changes: only allowed on drafts
+    if (input.content !== undefined && post.status !== 'draft') {
+      throw new ValidationError('Content can only be edited on draft posts');
+    }
+
+    // Validate rating constraints: NOT allowed on discarded posts (already blocked above)
+    if (input.rating !== undefined && input.rating !== null) {
+      if (input.rating < 1 || input.rating > 5 || !Number.isInteger(input.rating)) {
+        throw new ValidationError('Rating must be an integer between 1 and 5');
+      }
+    }
+
+    // Validate status transition
+    if (input.status) {
+      const allowed = getAllowedTransitions(post.status);
+      if (!allowed.includes(input.status)) {
+        throw new ValidationError(`Cannot transition from '${post.status}' to '${input.status}'`);
+      }
+    }
+
+    const updateData: {
+      content?: string;
+      status?: string;
+      rating?: number | null;
+      scheduledAt?: Date | null;
+      publishedAt?: Date | null;
+    } = {};
+
+    if (input.content !== undefined) {
+      updateData.content = input.content;
+    }
+
+    if (input.rating !== undefined) {
+      updateData.rating = input.rating;
+    }
+
+    if (input.status === 'scheduled') {
+      updateData.status = 'scheduled';
+      updateData.scheduledAt = input.scheduledAt ? new Date(input.scheduledAt) : new Date();
+    } else if (input.status === 'discarded') {
+      updateData.status = 'discarded';
+    }
+
+    return postRepository.update(postId, updateData);
+  },
+};
+
+function getAllowedTransitions(currentStatus: string): string[] {
+  switch (currentStatus) {
+    case 'draft':
+      return ['scheduled', 'discarded'];
+    case 'scheduled':
+      return ['discarded'];
+    default:
+      return [];
+  }
+}

--- a/api/src/services/xApiService.ts
+++ b/api/src/services/xApiService.ts
@@ -1,0 +1,102 @@
+import crypto from 'node:crypto';
+
+const TWITTER_TWEET_URL = 'https://api.twitter.com/2/tweets';
+
+function percentEncode(str: string): string {
+  return encodeURIComponent(str).replace(
+    /[!'()*]/g,
+    (c) => `%${c.charCodeAt(0).toString(16).toUpperCase()}`,
+  );
+}
+
+function generateNonce(): string {
+  return crypto.randomBytes(16).toString('hex');
+}
+
+function generateTimestamp(): string {
+  return Math.floor(Date.now() / 1000).toString();
+}
+
+function buildSignatureBaseString(
+  method: string,
+  url: string,
+  params: Record<string, string>,
+): string {
+  const sortedKeys = Object.keys(params).sort();
+  const paramString = sortedKeys
+    .map((key) => `${percentEncode(key)}=${percentEncode(params[key])}`)
+    .join('&');
+
+  return `${method.toUpperCase()}&${percentEncode(url)}&${percentEncode(paramString)}`;
+}
+
+function signHmacSha1(baseString: string, consumerSecret: string, tokenSecret: string): string {
+  const signingKey = `${percentEncode(consumerSecret)}&${percentEncode(tokenSecret)}`;
+  const hmac = crypto.createHmac('sha1', signingKey);
+  hmac.update(baseString);
+  return hmac.digest('base64');
+}
+
+function buildAuthorizationHeader(params: Record<string, string>): string {
+  const parts = Object.keys(params)
+    .sort()
+    .map((key) => `${percentEncode(key)}="${percentEncode(params[key])}"`)
+    .join(', ');
+  return `OAuth ${parts}`;
+}
+
+export async function publishTweet(
+  content: string,
+  accessToken: string,
+  accessSecret: string,
+): Promise<{ success: boolean; tweetId?: string; error?: string }> {
+  try {
+    const consumerKey = process.env.X_CONSUMER_KEY || '';
+    const consumerSecret = process.env.X_CONSUMER_SECRET || '';
+
+    const oauthParams: Record<string, string> = {
+      oauth_consumer_key: consumerKey,
+      oauth_nonce: generateNonce(),
+      oauth_signature_method: 'HMAC-SHA1',
+      oauth_timestamp: generateTimestamp(),
+      oauth_token: accessToken,
+      oauth_version: '1.0',
+    };
+
+    const baseString = buildSignatureBaseString('POST', TWITTER_TWEET_URL, oauthParams);
+    const signature = signHmacSha1(baseString, consumerSecret, accessSecret);
+
+    const headerParams = {
+      ...oauthParams,
+      oauth_signature: signature,
+    };
+
+    const response = await fetch(TWITTER_TWEET_URL, {
+      method: 'POST',
+      headers: {
+        Authorization: buildAuthorizationHeader(headerParams),
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ text: content }),
+    });
+
+    if (!response.ok) {
+      const text = await response.text();
+
+      // Handle rate limiting
+      if (response.status === 429) {
+        return { success: false, error: `Rate limited: ${text}` };
+      }
+
+      return { success: false, error: `X API error ${response.status}: ${text}` };
+    }
+
+    const data = (await response.json()) as { data?: { id?: string } };
+    const tweetId = data?.data?.id;
+
+    return { success: true, tweetId: tweetId ?? undefined };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Unknown error';
+    return { success: false, error: message };
+  }
+}

--- a/api/src/worker/index.ts
+++ b/api/src/worker/index.ts
@@ -1,11 +1,12 @@
 import * as jobWorker from './jobWorker.js';
 import * as staleLockRecovery from './staleLockRecovery.js';
+import * as postPublisher from './postPublisher.js';
 
 function shutdown(): void {
   console.log('[worker] Shutting down gracefully...');
   jobWorker.stop();
   staleLockRecovery.stop();
-  // Post publisher placeholder — will be added later
+  postPublisher.stop();
   process.exit(0);
 }
 
@@ -16,6 +17,6 @@ console.log('[worker] Starting worker processes...');
 
 jobWorker.start();
 staleLockRecovery.start();
-// Post publisher placeholder — will start here when implemented
+postPublisher.start();
 
 console.log('[worker] All worker processes started');

--- a/api/src/worker/postPublisher.ts
+++ b/api/src/worker/postPublisher.ts
@@ -1,0 +1,74 @@
+import { postRepository } from '../repositories/postRepository.js';
+import { publishTweet } from '../services/xApiService.js';
+
+const POLL_INTERVAL_MS = parseInt(process.env.POST_PUBLISHER_POLL_INTERVAL_MS || '30000', 10);
+const MAX_RETRIES = 3;
+
+let intervalHandle: ReturnType<typeof setInterval> | null = null;
+let running = false;
+
+// In-memory retry counter: postId -> failure count
+const retryCounts = new Map<string, number>();
+
+async function publishPosts(): Promise<void> {
+  if (running) return;
+  running = true;
+
+  try {
+    const posts = await postRepository.findScheduledReady(20);
+
+    for (const post of posts) {
+      // Skip posts that have exceeded retry limit
+      const currentRetries = retryCounts.get(post.id) ?? 0;
+      if (currentRetries >= MAX_RETRIES) {
+        console.warn(
+          `[postPublisher] Post ${post.id} has reached max retries (${MAX_RETRIES}), skipping`,
+        );
+        continue;
+      }
+
+      const bot = post.bot;
+      const result = await publishTweet(post.content, bot.xAccessToken, bot.xAccessSecret);
+
+      if (result.success) {
+        await postRepository.update(post.id, {
+          status: 'published',
+          publishedAt: new Date(),
+        });
+
+        // Clean up retry counter on success
+        retryCounts.delete(post.id);
+
+        console.log(
+          `[postPublisher] Published post ${post.id} as tweet ${result.tweetId ?? 'unknown'}`,
+        );
+      } else {
+        const newCount = currentRetries + 1;
+        retryCounts.set(post.id, newCount);
+
+        console.error(
+          `[postPublisher] Failed to publish post ${post.id} (attempt ${newCount}/${MAX_RETRIES}): ${result.error}`,
+        );
+      }
+    }
+  } catch (err) {
+    console.error('[postPublisher] Error polling for scheduled posts:', err);
+  } finally {
+    running = false;
+  }
+}
+
+export function start(pollIntervalMs?: number): void {
+  const interval = pollIntervalMs ?? POLL_INTERVAL_MS;
+  console.log(`[postPublisher] Starting with poll interval ${interval}ms`);
+  void publishPosts();
+  intervalHandle = setInterval(() => void publishPosts(), interval);
+}
+
+export function stop(): void {
+  if (intervalHandle) {
+    clearInterval(intervalHandle);
+    intervalHandle = null;
+  }
+  console.log('[postPublisher] Stopped');
+}


### PR DESCRIPTION
## Summary
- **Post management API** (Issue #11): Added `GET /api/posts` (list with pagination/status filter) and `PATCH /api/posts/:id` (update content, rating, status) with full status transition validation and authorization checks
- **X post publisher worker** (Issue #12): Added a polling worker that publishes scheduled posts to X via OAuth 1.0a signed API calls, with in-memory retry tracking (max 3 attempts)
- Added `xApiService` for X API v2 tweet creation with proper OAuth 1.0a signing
- Updated `postRepository` with `findById`, `findByBotIds`, `findScheduledReady`, and generic `update` methods

Closes #11, Closes #12

## Test plan
- [ ] Verify `GET /api/posts` returns paginated posts filtered by authenticated user's bots
- [ ] Verify `GET /api/posts?status=draft` filters correctly
- [ ] Verify `PATCH /api/posts/:id` allows content edit on draft posts only
- [ ] Verify rating can be set (1-5) on draft/scheduled/published but not discarded
- [ ] Verify status transitions: draft→scheduled, draft→discarded, scheduled→discarded
- [ ] Verify published/discarded posts cannot be modified
- [ ] Verify authorization: users cannot modify posts from other users' bots
- [ ] Verify post publisher picks up scheduled posts with scheduled_at <= now
- [ ] Verify post publisher marks posts as published on success
- [ ] Verify post publisher retries up to 3 times on failure then stops

🤖 Generated with [Claude Code](https://claude.com/claude-code)