### PR TITLE
feat: dashboard stats, rate limiting, and API hardening

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -20,6 +20,7 @@
     "cookie-parser": "^1.4.7",
     "cors": "^2.8.5",
     "express": "^4.21.2",
+    "express-rate-limit": "^8.3.1",
     "helmet": "^8.0.0",
     "jsonwebtoken": "^9.0.2",
     "uuid": "^11.1.0",

--- a/api/src/controllers/statsController.ts
+++ b/api/src/controllers/statsController.ts
@@ -1,0 +1,63 @@
+import { Request, Response, NextFunction } from 'express';
+import { z } from 'zod';
+import { uuidSchema } from '../utils/validation.js';
+import { botService } from '../services/botService.js';
+import { prisma } from '../utils/prisma.js';
+
+const botIdParamSchema = z.object({
+  id: uuidSchema,
+});
+
+export const statsController = {
+  async getBotStats(req: Request, res: Response, next: NextFunction): Promise<void> {
+    try {
+      const userId = req.userId!;
+      const { id: botId } = botIdParamSchema.parse(req.params);
+
+      // Verify ownership (throws NotFound/Forbidden if invalid)
+      await botService.getBot(botId, userId);
+
+      const todayStart = new Date();
+      todayStart.setHours(0, 0, 0, 0);
+
+      const [
+        totalPosts,
+        postsToday,
+        ratingAgg,
+        draftCount,
+        scheduledCount,
+        publishedCount,
+        discardedCount,
+      ] = await Promise.all([
+        prisma.post.count({ where: { botId } }),
+        prisma.post.count({
+          where: { botId, createdAt: { gte: todayStart } },
+        }),
+        prisma.post.aggregate({
+          where: { botId, rating: { not: null } },
+          _avg: { rating: true },
+        }),
+        prisma.post.count({ where: { botId, status: 'draft' } }),
+        prisma.post.count({ where: { botId, status: 'scheduled' } }),
+        prisma.post.count({ where: { botId, status: 'published' } }),
+        prisma.post.count({ where: { botId, status: 'discarded' } }),
+      ]);
+
+      res.status(200).json({
+        data: {
+          totalPosts,
+          postsToday,
+          averageRating: ratingAgg._avg.rating ?? null,
+          postsByStatus: {
+            draft: draftCount,
+            scheduled: scheduledCount,
+            published: publishedCount,
+            discarded: discardedCount,
+          },
+        },
+      });
+    } catch (err) {
+      next(err);
+    }
+  },
+};

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -3,6 +3,7 @@ import cors from 'cors';
 import helmet from 'helmet';
 import cookieParser from 'cookie-parser';
 import { config } from './config/index.js';
+import { requestIdMiddleware } from './middleware/requestId.js';
 import { requestLogger } from './middleware/requestLogger.js';
 import { errorHandler } from './middleware/errorHandler.js';
 import { notFoundHandler } from './middleware/notFound.js';
@@ -11,6 +12,7 @@ import authRoutes from './routes/authRoutes.js';
 import botRoutes from './routes/botRoutes.js';
 import xOAuthRoutes from './routes/xOAuthRoutes.js';
 import postRoutes from './routes/postRoutes.js';
+import statsRoutes from './routes/statsRoutes.js';
 
 const app = express();
 
@@ -19,12 +21,14 @@ app.use(helmet());
 app.use(cors());
 app.use(cookieParser());
 app.use(express.json());
+app.use(requestIdMiddleware);
 app.use(requestLogger);
 
 // Routes
 app.use('/api/health', healthRoutes);
 app.use('/api/auth', authRoutes);
 app.use('/api/bots', botRoutes);
+app.use('/api/bots', statsRoutes);
 app.use('/api/auth/x', xOAuthRoutes);
 app.use('/api/posts', postRoutes);
 

--- a/api/src/middleware/requestId.ts
+++ b/api/src/middleware/requestId.ts
@@ -1,0 +1,8 @@
+import { Request, Response, NextFunction } from 'express';
+import { v4 as uuidv4 } from 'uuid';
+
+export function requestIdMiddleware(req: Request, res: Response, next: NextFunction): void {
+  const requestId = (req.headers['x-request-id'] as string) || uuidv4();
+  res.setHeader('X-Request-ID', requestId);
+  next();
+}

--- a/api/src/routes/authRoutes.ts
+++ b/api/src/routes/authRoutes.ts
@@ -1,11 +1,24 @@
 import { Router } from 'express';
+import rateLimit from 'express-rate-limit';
 import { authController } from '../controllers/authController.js';
 import { authMiddleware } from '../middleware/auth.js';
 
 const router = Router();
 
+const magicLinkLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 5,
+  standardHeaders: true,
+  legacyHeaders: false,
+  message: {
+    error: 'TOO_MANY_REQUESTS',
+    statusCode: 429,
+    message: 'Too many magic link requests. Please try again later.',
+  },
+});
+
 // Public routes
-router.post('/magic-link', authController.requestMagicLink);
+router.post('/magic-link', magicLinkLimiter, authController.requestMagicLink);
 router.get('/verify', authController.verify);
 
 // Protected routes

--- a/api/src/routes/statsRoutes.ts
+++ b/api/src/routes/statsRoutes.ts
@@ -1,0 +1,12 @@
+import { Router } from 'express';
+import { statsController } from '../controllers/statsController.js';
+import { authMiddleware } from '../middleware/auth.js';
+
+const router = Router();
+
+// All stats routes require authentication
+router.use(authMiddleware);
+
+router.get('/:id/stats', statsController.getBotStats);
+
+export default router;

--- a/api/src/worker/index.ts
+++ b/api/src/worker/index.ts
@@ -2,16 +2,39 @@ import * as jobWorker from './jobWorker.js';
 import * as staleLockRecovery from './staleLockRecovery.js';
 import * as postPublisher from './postPublisher.js';
 
-function shutdown(): void {
-  console.log('[worker] Shutting down gracefully...');
+let isShuttingDown = false;
+
+function shutdown(signal: string): void {
+  if (isShuttingDown) {
+    console.log(`[worker] Received ${signal} again during shutdown, forcing exit`);
+    process.exit(1);
+  }
+
+  isShuttingDown = true;
+  console.log(`[worker] Received ${signal}. Shutting down gracefully...`);
+
   jobWorker.stop();
   staleLockRecovery.stop();
   postPublisher.stop();
-  process.exit(0);
+
+  // Allow a short window for in-flight work to finish
+  setTimeout(() => {
+    console.log('[worker] Shutdown complete');
+    process.exit(0);
+  }, 5000);
 }
 
-process.on('SIGTERM', shutdown);
-process.on('SIGINT', shutdown);
+process.on('SIGTERM', () => shutdown('SIGTERM'));
+process.on('SIGINT', () => shutdown('SIGINT'));
+
+process.on('uncaughtException', (err) => {
+  console.error('[worker] Uncaught exception:', err);
+  shutdown('uncaughtException');
+});
+
+process.on('unhandledRejection', (reason) => {
+  console.error('[worker] Unhandled rejection:', reason);
+});
 
 console.log('[worker] Starting worker processes...');
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "cookie-parser": "^1.4.7",
         "cors": "^2.8.5",
         "express": "^4.21.2",
+        "express-rate-limit": "^8.3.1",
         "helmet": "^8.0.0",
         "jsonwebtoken": "^9.0.2",
         "uuid": "^11.1.0",
@@ -3439,6 +3440,23 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/express-rate-limit": {
+      "version": "8.3.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.1.tgz",
+      "integrity": "sha512-D1dKN+cmyPWuvB+G2SREQDzPY1agpBIcTa9sJxOPMCNeH3gwzhqJRDWCXW3gg0y//+LQ/8j52JbMROWyrKdMdw==",
+      "dependencies": {
+        "ip-address": "10.1.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
     "node_modules/express/node_modules/debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -4063,6 +4081,14 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "node_modules/ip-address": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "engines": {
+        "node": ">= 12"
+      }
     },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",

--- a/web/src/hooks/useStats.ts
+++ b/web/src/hooks/useStats.ts
@@ -1,0 +1,30 @@
+import { useQuery } from '@tanstack/react-query';
+import { apiClient } from '../lib/apiClient';
+import { queryKeys } from '../lib/queryKeys';
+
+export type BotStats = {
+  totalPosts: number;
+  postsToday: number;
+  averageRating: number | null;
+  postsByStatus: {
+    draft: number;
+    scheduled: number;
+    published: number;
+    discarded: number;
+  };
+};
+
+type StatsResponse = {
+  data: BotStats;
+};
+
+export function useStats(botId: string | undefined) {
+  return useQuery({
+    queryKey: queryKeys.stats.forBot(botId ?? ''),
+    queryFn: async () => {
+      const response = await apiClient.get<StatsResponse>(`/bots/${botId}/stats`);
+      return response.data.data;
+    },
+    enabled: !!botId,
+  });
+}

--- a/web/src/lib/queryKeys.ts
+++ b/web/src/lib/queryKeys.ts
@@ -11,4 +11,7 @@ export const queryKeys = {
       ['posts', 'list', status ?? 'all', page ?? 1] as const,
     all: ['posts'] as const,
   },
+  stats: {
+    forBot: (botId: string) => ['stats', 'bot', botId] as const,
+  },
 } as const;

--- a/web/src/pages/DashboardPage.tsx
+++ b/web/src/pages/DashboardPage.tsx
@@ -5,22 +5,52 @@ import Card from '@mui/material/Card';
 import CardContent from '@mui/material/CardContent';
 import Chip from '@mui/material/Chip';
 import Container from '@mui/material/Container';
+import Grid from '@mui/material/Grid';
 import Switch from '@mui/material/Switch';
 import Typography from '@mui/material/Typography';
 import CircularProgress from '@mui/material/CircularProgress';
 import Dialog from '@mui/material/Dialog';
 import DialogTitle from '@mui/material/DialogTitle';
 import DialogContent from '@mui/material/DialogContent';
+import Skeleton from '@mui/material/Skeleton';
 import AppHeader from '../components/AppHeader';
 import BotSetupForm from '../components/BotSetupForm';
 import { useBot, useUpdateBot } from '../hooks/useBot';
+import { useStats } from '../hooks/useStats';
+import { usePosts, type PostStatus } from '../hooks/usePosts';
 import { apiClient } from '../lib/apiClient';
+import { useNavigate } from '@tanstack/react-router';
+
+const statusColors: Record<PostStatus, 'default' | 'info' | 'success' | 'error'> = {
+  draft: 'default',
+  scheduled: 'info',
+  published: 'success',
+  discarded: 'error',
+};
+
+function StatCard({ title, value }: { title: string; value: string | number }) {
+  return (
+    <Card>
+      <CardContent sx={{ textAlign: 'center', py: 2 }}>
+        <Typography variant="body2" color="text.secondary" gutterBottom>
+          {title}
+        </Typography>
+        <Typography variant="h4">{value}</Typography>
+      </CardContent>
+    </Card>
+  );
+}
 
 export default function DashboardPage() {
   const { bot, isLoading } = useBot();
   const updateBot = useUpdateBot();
   const [editOpen, setEditOpen] = useState(false);
   const [connectLoading, setConnectLoading] = useState(false);
+  const navigate = useNavigate();
+
+  const { data: stats, isLoading: statsLoading } = useStats(bot?.id);
+  const { data: recentPostsData, isLoading: recentPostsLoading } = usePosts(undefined, 1, 5);
+  const recentPosts = recentPostsData?.data ?? [];
 
   const handleToggleActive = () => {
     if (!bot) return;
@@ -143,6 +173,117 @@ export default function DashboardPage() {
             </Box>
           </CardContent>
         </Card>
+
+        {/* Stats Section */}
+        {statsLoading ? (
+          <Grid container spacing={2} sx={{ mb: 3 }}>
+            {[1, 2, 3, 4].map((i) => (
+              <Grid item xs={6} sm={3} key={i}>
+                <Skeleton variant="rectangular" height={100} sx={{ borderRadius: 1 }} />
+              </Grid>
+            ))}
+          </Grid>
+        ) : stats ? (
+          <>
+            <Typography variant="h6" gutterBottom>
+              Stats
+            </Typography>
+            <Grid container spacing={2} sx={{ mb: 3 }}>
+              <Grid item xs={6} sm={3}>
+                <StatCard title="Total Posts" value={stats.totalPosts} />
+              </Grid>
+              <Grid item xs={6} sm={3}>
+                <StatCard title="Posts Today" value={stats.postsToday} />
+              </Grid>
+              <Grid item xs={6} sm={3}>
+                <StatCard
+                  title="Avg Rating"
+                  value={stats.averageRating != null ? stats.averageRating.toFixed(1) : 'N/A'}
+                />
+              </Grid>
+              <Grid item xs={6} sm={3}>
+                <StatCard title="Published" value={stats.postsByStatus.published} />
+              </Grid>
+            </Grid>
+            <Grid container spacing={2} sx={{ mb: 3 }}>
+              <Grid item xs={6} sm={3}>
+                <StatCard title="Drafts" value={stats.postsByStatus.draft} />
+              </Grid>
+              <Grid item xs={6} sm={3}>
+                <StatCard title="Scheduled" value={stats.postsByStatus.scheduled} />
+              </Grid>
+              <Grid item xs={6} sm={3}>
+                <StatCard title="Discarded" value={stats.postsByStatus.discarded} />
+              </Grid>
+            </Grid>
+          </>
+        ) : null}
+
+        {/* Recent Posts */}
+        <Typography variant="h6" gutterBottom>
+          Recent Posts
+        </Typography>
+        {recentPostsLoading ? (
+          <Box>
+            {[1, 2, 3].map((i) => (
+              <Skeleton key={i} variant="rectangular" height={60} sx={{ mb: 1, borderRadius: 1 }} />
+            ))}
+          </Box>
+        ) : recentPosts.length === 0 ? (
+          <Card sx={{ mb: 3 }}>
+            <CardContent>
+              <Typography variant="body2" color="text.secondary" textAlign="center">
+                No posts yet
+              </Typography>
+            </CardContent>
+          </Card>
+        ) : (
+          <Card sx={{ mb: 3 }}>
+            <CardContent sx={{ p: 0, '&:last-child': { pb: 0 } }}>
+              {recentPosts.map((post, index) => (
+                <Box
+                  key={post.id}
+                  sx={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'space-between',
+                    px: 2,
+                    py: 1.5,
+                    borderBottom: index < recentPosts.length - 1 ? '1px solid' : 'none',
+                    borderColor: 'divider',
+                  }}
+                >
+                  <Typography
+                    variant="body2"
+                    sx={{
+                      overflow: 'hidden',
+                      textOverflow: 'ellipsis',
+                      whiteSpace: 'nowrap',
+                      mr: 2,
+                      flex: 1,
+                    }}
+                  >
+                    {post.content}
+                  </Typography>
+                  <Chip label={post.status} color={statusColors[post.status]} size="small" />
+                </Box>
+              ))}
+            </CardContent>
+          </Card>
+        )}
+
+        {/* Quick Actions */}
+        <Typography variant="h6" gutterBottom>
+          Quick Actions
+        </Typography>
+        <Box sx={{ display: 'flex', gap: 2, mb: 4 }}>
+          <Button variant="contained" onClick={() => void navigate({ to: '/posts' })}>
+            View Post Queue
+          </Button>
+          <Button variant="outlined" onClick={() => setEditOpen(true)}>
+            Edit Bot Config
+          </Button>
+        </Box>
 
         <Dialog open={editOpen} onClose={() => setEditOpen(false)} maxWidth="sm" fullWidth>
           <DialogTitle>Edit Bot Configuration</DialogTitle>


### PR DESCRIPTION
## Summary
- **Stats endpoint** (`GET /api/bots/:id/stats`): returns totalPosts, postsToday, averageRating, and postsByStatus breakdown — auth-protected with ownership check
- **Dashboard overhaul**: stat cards (MUI Grid), recent posts list with status badges, and quick-action buttons (view post queue, edit bot config) via new `useStats` hook
- **Rate limiting**: `express-rate-limit` on `POST /api/auth/magic-link` (5 req / 15 min per IP)
- **Request ID middleware**: generates/forwards `X-Request-ID` header on every response
- **Worker shutdown hardening**: duplicate-signal guard, 5 s drain timeout, uncaughtException handler

Closes #14, Closes #16

## Test plan
- [ ] `GET /api/bots/:id/stats` returns correct aggregated numbers
- [ ] Stats endpoint returns 403 for non-owner, 404 for missing bot
- [ ] Dashboard renders stat cards, recent posts, and quick actions
- [ ] Magic-link endpoint returns 429 after 5 rapid requests
- [ ] `X-Request-ID` header present on all API responses
- [ ] Worker shuts down cleanly on SIGTERM without orphaned processes

🤖 Generated with [Claude Code](https://claude.com/claude-code)