### PR TITLE
Deployment config — Render + Vercel

### DIFF
--- a/api/.env.example
+++ b/api/.env.example
@@ -1,6 +1,23 @@
-DATABASE_URL=postgresql://postgres:postgres@localhost:5432/xbot?schema=public
-JWT_SECRET=your-jwt-secret-here
-ANTHROPIC_API_KEY=your-anthropic-api-key-here
-X_CONSUMER_KEY=your-x-consumer-key-here
-X_CONSUMER_SECRET=your-x-consumer-secret-here
+# Database
+DATABASE_URL=postgresql://user:password@localhost:5432/xbot
+
+# Auth
+JWT_SECRET=change-me-in-production
+
+# App URLs
+APP_BASE_URL=http://localhost:3001
+FRONTEND_URL=http://localhost:3000
+
+# AI
+ANTHROPIC_API_KEY=sk-ant-...
+
+# X (Twitter) OAuth 1.0a
+X_CONSUMER_KEY=your-consumer-key
+X_CONSUMER_SECRET=your-consumer-secret
+
+# Server
 PORT=3001
+NODE_ENV=development
+
+# Worker
+WORKER_POLL_INTERVAL_MS=30000

--- a/api/package.json
+++ b/api/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "build": "tsc",
     "dev": "nodemon --exec tsx src/index.ts",
-    "start": "node dist/index.js",
+    "start": "npx prisma migrate deploy && node dist/index.js",
+    "start:worker": "npx prisma migrate deploy && node dist/worker/index.js",
     "prisma:generate": "prisma generate",
     "prisma:migrate": "prisma migrate dev",
     "prisma:seed": "tsx prisma/seed.ts",

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -18,7 +18,12 @@ const app = express();
 
 // Global middleware
 app.use(helmet());
-app.use(cors());
+app.use(
+  cors({
+    origin: config.app.frontendUrl,
+    credentials: true,
+  }),
+);
 app.use(cookieParser());
 app.use(express.json());
 app.use(requestIdMiddleware);

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,57 @@
+databases:
+  - name: x-bot-db
+    plan: free
+    databaseName: xbot
+    user: xbot
+
+services:
+  - type: web
+    name: x-bot-api
+    runtime: node
+    plan: free
+    rootDir: .
+    buildCommand: npm ci && npx prisma generate --schema=api/prisma/schema.prisma && npm run build --workspace=shared && npm run build --workspace=api
+    startCommand: cd api && npm run start
+    healthCheckPath: /api/health
+    envVars:
+      - key: NODE_ENV
+        value: production
+      - key: DATABASE_URL
+        fromDatabase:
+          name: x-bot-db
+          property: connectionString
+      - key: JWT_SECRET
+        generateValue: true
+      - key: APP_BASE_URL
+        sync: false
+      - key: FRONTEND_URL
+        sync: false
+      - key: ANTHROPIC_API_KEY
+        sync: false
+      - key: X_CONSUMER_KEY
+        sync: false
+      - key: X_CONSUMER_SECRET
+        sync: false
+
+  - type: worker
+    name: x-bot-worker
+    runtime: node
+    plan: free
+    rootDir: .
+    buildCommand: npm ci && npx prisma generate --schema=api/prisma/schema.prisma && npm run build --workspace=shared && npm run build --workspace=api
+    startCommand: cd api && npm run start:worker
+    envVars:
+      - key: NODE_ENV
+        value: production
+      - key: DATABASE_URL
+        fromDatabase:
+          name: x-bot-db
+          property: connectionString
+      - key: ANTHROPIC_API_KEY
+        sync: false
+      - key: X_CONSUMER_KEY
+        sync: false
+      - key: X_CONSUMER_SECRET
+        sync: false
+      - key: WORKER_POLL_INTERVAL_MS
+        value: '30000'

--- a/web/src/lib/apiClient.ts
+++ b/web/src/lib/apiClient.ts
@@ -1,6 +1,8 @@
 import axios from 'axios';
 
+const baseURL = import.meta.env.VITE_API_URL ? `${import.meta.env.VITE_API_URL}/api` : '/api';
+
 export const apiClient = axios.create({
-  baseURL: '/api',
+  baseURL,
   withCredentials: true,
 });

--- a/web/vercel.json
+++ b/web/vercel.json
@@ -1,0 +1,6 @@
+{
+  "buildCommand": "cd .. && npm ci && npm run build --workspace=shared && npm run build --workspace=web",
+  "outputDirectory": "dist",
+  "framework": "vite",
+  "rewrites": [{ "source": "/(.*)", "destination": "/index.html" }]
+}


### PR DESCRIPTION
## Summary
- `render.yaml` — Render Blueprint with API web service, background worker, and PostgreSQL database
- `web/vercel.json` — Vercel config for Vite SPA with client-side routing rewrites
- API `start` script runs `prisma migrate deploy` before `node dist/index.js`
- Separate `start:worker` script for the background job processor
- CORS configured with `FRONTEND_URL` for cross-origin cookie auth
- Web `apiClient` reads `VITE_API_URL` env var in production (falls back to `/api` proxy in dev)

Closes #17

## Setup Instructions

### Render
1. Go to Render Dashboard → **New** → **Blueprint**
2. Connect this repo, Render will read `render.yaml`
3. Set these env vars on both API and Worker services:
   - `APP_BASE_URL` — your Render API URL (e.g. `https://x-bot-api.onrender.com`)
   - `FRONTEND_URL` — your Vercel URL (e.g. `https://x-bot.vercel.app`)
   - `ANTHROPIC_API_KEY` — your Anthropic API key
   - `X_CONSUMER_KEY` / `X_CONSUMER_SECRET` — X developer app credentials
4. `DATABASE_URL` and `JWT_SECRET` are auto-configured by the blueprint

### Vercel
1. Import the repo in Vercel
2. Set **Root Directory** to `web`
3. Framework: **Vite**
4. Set env var: `VITE_API_URL` = your Render API URL (e.g. `https://x-bot-api.onrender.com`)
5. Deploy

## Test plan
- [x] All CI checks pass locally (prettier, eslint, typecheck, build, E2E)
- [ ] Render Blueprint deploys API + Worker + PG
- [ ] Vercel deploys web SPA
- [ ] `/api/health` returns 200 on Render
- [ ] Web loads and auth flow works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)