### PR TITLE
Run workers in-process, remove separate worker service

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -6,7 +6,6 @@
     "build": "tsc",
     "dev": "nodemon --exec tsx src/index.ts",
     "start": "npx prisma migrate deploy && node dist/index.js",
-    "start:worker": "npx prisma migrate deploy && node dist/worker/index.js",
     "prisma:generate": "prisma generate",
     "prisma:migrate": "prisma migrate dev",
     "prisma:seed": "tsx prisma/seed.ts",

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -13,6 +13,9 @@ import botRoutes from './routes/botRoutes.js';
 import xOAuthRoutes from './routes/xOAuthRoutes.js';
 import postRoutes from './routes/postRoutes.js';
 import statsRoutes from './routes/statsRoutes.js';
+import * as jobWorker from './worker/jobWorker.js';
+import * as staleLockRecovery from './worker/staleLockRecovery.js';
+import * as postPublisher from './worker/postPublisher.js';
 
 const app = express();
 
@@ -46,6 +49,20 @@ app.use(errorHandler);
 // Start server
 app.listen(config.port, () => {
   console.log(`API server listening on port ${config.port}`);
+
+  // Start workers in-process (safe to run multiple instances via SKIP LOCKED)
+  jobWorker.start();
+  staleLockRecovery.start();
+  postPublisher.start();
+  console.log('Workers started in-process');
+});
+
+// Graceful shutdown
+process.on('SIGTERM', () => {
+  jobWorker.stop();
+  staleLockRecovery.stop();
+  postPublisher.stop();
+  process.exit(0);
 });
 
 export default app;

--- a/render.yaml
+++ b/render.yaml
@@ -32,26 +32,3 @@ services:
         sync: false
       - key: X_CONSUMER_SECRET
         sync: false
-
-  - type: worker
-    name: x-bot-worker
-    runtime: node
-    plan: free
-    rootDir: .
-    buildCommand: npm ci && npx prisma generate --schema=api/prisma/schema.prisma && npm run build --workspace=shared && npm run build --workspace=api
-    startCommand: cd api && npm run start:worker
-    envVars:
-      - key: NODE_ENV
-        value: production
-      - key: DATABASE_URL
-        fromDatabase:
-          name: x-bot-db
-          property: connectionString
-      - key: ANTHROPIC_API_KEY
-        sync: false
-      - key: X_CONSUMER_KEY
-        sync: false
-      - key: X_CONSUMER_SECRET
-        sync: false
-      - key: WORKER_POLL_INTERVAL_MS
-        value: '30000'


### PR DESCRIPTION
## Summary
- Workers (job poller, post publisher, stale lock recovery) now start inside the API process after server listen
- Removed separate worker service from `render.yaml`
- Removed `start:worker` script from `api/package.json`
- Added graceful SIGTERM shutdown for workers
- Safe to run multiple API instances — job claiming uses `SELECT FOR UPDATE SKIP LOCKED`

🤖 Generated with [Claude Code](https://claude.com/claude-code)