### PR TITLE
Fix Render build: include devDependencies for TS compilation

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -10,7 +10,7 @@ services:
     runtime: node
     plan: free
     rootDir: .
-    buildCommand: npm ci && npx prisma generate --schema=api/prisma/schema.prisma && npm run build --workspace=shared && npm run build --workspace=api
+    buildCommand: npm ci --include=dev && npx prisma generate --schema=api/prisma/schema.prisma && npm run build --workspace=shared && npm run build --workspace=api
     startCommand: cd api && npm run start
     healthCheckPath: /api/health
     envVars:


### PR DESCRIPTION
## Summary
- Add `--include=dev` to `npm ci` in render.yaml so @types/* packages are available during `tsc` build

🤖 Generated with [Claude Code](https://claude.com/claude-code)