### PR TITLE
fix: hide allowed email domains from error messages

### DIFF
--- a/api/src/services/authService.ts
+++ b/api/src/services/authService.ts
@@ -8,9 +8,7 @@ export const authService = {
   validateEmailDomain(email: string): void {
     const domain = email.split('@')[1];
     if (!domain || !config.allowedDomains.includes(domain)) {
-      throw new ValidationError(
-        `Email domain not allowed. Allowed domains: ${config.allowedDomains.join(', ')}`,
-      );
+      throw new ValidationError('Your email is not allowed');
     }
   },
 

--- a/web/src/pages/LoginPage.tsx
+++ b/web/src/pages/LoginPage.tsx
@@ -16,7 +16,7 @@ function validateEmail(email: string): string | null {
   if (parts.length !== 2) return 'Invalid email address';
   const domain = parts[1];
   if (!ALLOWED_DOMAINS.includes(domain)) {
-    return `Email must be from: ${ALLOWED_DOMAINS.join(', ')}`;
+    return 'Your email is not allowed';
   }
   return null;
 }


### PR DESCRIPTION
## Summary
- Replace "Email must be from: thestartupfactory.tech, ehe.ai" with generic "Your email is not allowed" on frontend
- Replace "Email domain not allowed. Allowed domains: ..." with same generic message in API response

## Test plan
- [ ] Enter non-allowed email on login page — should show "Your email is not allowed" without listing domains

🤖 Generated with [Claude Code](https://claude.com/claude-code)