### PR TITLE
fix: use sameSite=none for cross-domain cookies in production

### DIFF
--- a/api/src/controllers/authController.ts
+++ b/api/src/controllers/authController.ts
@@ -19,7 +19,7 @@ function setSessionCookie(res: Response, sessionToken: string): void {
   res.cookie(config.cookie.name, sessionToken, {
     httpOnly: true,
     secure: config.isProduction,
-    sameSite: 'lax',
+    sameSite: config.isProduction ? 'none' : 'lax',
     maxAge: config.cookie.maxAge,
     path: '/',
   });
@@ -61,7 +61,7 @@ export const authController = {
       res.clearCookie(config.cookie.name, {
         httpOnly: true,
         secure: config.isProduction,
-        sameSite: 'lax',
+        sameSite: config.isProduction ? 'none' : 'lax',
         path: '/',
       });
 


### PR DESCRIPTION
## Summary
- Set `sameSite: 'none'` + `secure: true` for session cookies in production
- Required because frontend (vercel.app) and API (onrender.com) are different domains
- `sameSite: 'lax'` blocks browsers from sending cookies on cross-origin requests
- Keeps `sameSite: 'lax'` in development (same origin)

## Test plan
- [ ] Login on production → cookie is sent with subsequent API requests
- [ ] /auth/me returns user data instead of 401

🤖 Generated with [Claude Code](https://claude.com/claude-code)