### PR TITLE
fix: job scheduling reliability + error tracking

### DIFF
--- a/api/prisma/migrations/20260313030000_add_job_error/migration.sql
+++ b/api/prisma/migrations/20260313030000_add_job_error/migration.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "Job" ADD COLUMN "error" TEXT;

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -65,6 +65,7 @@ model Job {
   scheduledAt DateTime
   startedAt   DateTime?
   completedAt DateTime?
+  error       String?   @db.Text
   createdAt   DateTime  @default(now())
 
   bot   Bot    @relation(fields: [botId], references: [id])

--- a/api/src/controllers/jobQueueController.ts
+++ b/api/src/controllers/jobQueueController.ts
@@ -78,6 +78,7 @@ export const jobQueueController = {
         scheduledAt: Date;
         startedAt: Date | null;
         completedAt: Date | null;
+        error: string | null;
         createdAt: Date;
         bot: { xAccountHandle: string };
       }) => ({
@@ -88,6 +89,7 @@ export const jobQueueController = {
         scheduledAt: job.scheduledAt,
         ...(job.startedAt && { startedAt: job.startedAt }),
         ...(job.completedAt && { completedAt: job.completedAt }),
+        error: job.error ?? null,
         createdAt: job.createdAt,
       });
 

--- a/api/src/repositories/jobRepository.ts
+++ b/api/src/repositories/jobRepository.ts
@@ -88,12 +88,13 @@ export const jobRepository = {
     });
   },
 
-  async markFailed(jobId: string) {
+  async markFailed(jobId: string, error?: string) {
     return prisma.job.update({
       where: { id: jobId },
       data: {
         status: 'failed',
         completedAt: new Date(),
+        error: error ?? null,
       },
     });
   },

--- a/api/src/worker/jobWorker.ts
+++ b/api/src/worker/jobWorker.ts
@@ -9,6 +9,34 @@ const POLL_INTERVAL_MS = parseInt(process.env.WORKER_POLL_INTERVAL_MS || '30000'
 let intervalHandle: ReturnType<typeof setInterval> | null = null;
 let running = false;
 
+async function scheduleNextJob(bot: {
+  id: string;
+  postsPerDay: number;
+  minIntervalHours: number;
+  preferredHoursStart: number;
+  preferredHoursEnd: number;
+}): Promise<void> {
+  const nextScheduledAt = computeNextScheduledAt(
+    {
+      postsPerDay: bot.postsPerDay,
+      minIntervalHours: bot.minIntervalHours,
+      preferredHoursStart: bot.preferredHoursStart,
+      preferredHoursEnd: bot.preferredHoursEnd,
+    },
+    new Date(),
+  );
+
+  await jobRepository.create({
+    botId: bot.id,
+    scheduledAt: nextScheduledAt,
+    status: 'pending',
+  });
+
+  console.log(
+    `[jobWorker] Next job for bot ${bot.id} scheduled at ${nextScheduledAt.toISOString()}`,
+  );
+}
+
 async function processJobs(): Promise<void> {
   if (running) return;
   running = true;
@@ -24,13 +52,23 @@ async function processJobs(): Promise<void> {
         continue;
       }
 
+      const bot = job.bot;
+
       try {
-        const bot = job.bot;
+        // Check if X account is connected
+        if (!bot.xAccessToken) {
+          const errorMsg = 'X account not connected — skipping content generation';
+          console.warn(`[jobWorker] Job ${job.id}: ${errorMsg}`);
+          await jobRepository.markFailed(job.id, errorMsg);
+          continue;
+        }
+
         const result = await generateTweet(bot.prompt);
 
         if (!result.success) {
-          console.error(`[jobWorker] AI generation failed for job ${job.id}: ${result.error}`);
-          await jobRepository.markFailed(job.id);
+          const errorMsg = `AI generation failed: ${result.error}`;
+          console.error(`[jobWorker] Job ${job.id}: ${errorMsg}`);
+          await jobRepository.markFailed(job.id, errorMsg);
           continue;
         }
 
@@ -46,30 +84,18 @@ async function processJobs(): Promise<void> {
         });
 
         await jobRepository.markCompleted(job.id);
-
-        // Schedule next job
-        const nextScheduledAt = computeNextScheduledAt(
-          {
-            postsPerDay: bot.postsPerDay,
-            minIntervalHours: bot.minIntervalHours,
-            preferredHoursStart: bot.preferredHoursStart,
-            preferredHoursEnd: bot.preferredHoursEnd,
-          },
-          new Date(),
-        );
-
-        await jobRepository.create({
-          botId: bot.id,
-          scheduledAt: nextScheduledAt,
-          status: 'pending',
-        });
-
-        console.log(
-          `[jobWorker] Job ${job.id} completed. Next job scheduled at ${nextScheduledAt.toISOString()}`,
-        );
+        console.log(`[jobWorker] Job ${job.id} completed successfully`);
       } catch (err) {
+        const errorMsg = err instanceof Error ? `${err.message}\n${err.stack}` : String(err);
         console.error(`[jobWorker] Error processing job ${job.id}:`, err);
-        await jobRepository.markFailed(job.id);
+        await jobRepository.markFailed(job.id, errorMsg);
+      } finally {
+        // Always schedule next job, even after failure
+        try {
+          await scheduleNextJob(bot);
+        } catch (schedErr) {
+          console.error(`[jobWorker] Failed to schedule next job for bot ${bot.id}:`, schedErr);
+        }
       }
     }
   } catch (err) {

--- a/api/src/worker/postPublisher.ts
+++ b/api/src/worker/postPublisher.ts
@@ -49,6 +49,14 @@ async function publishPosts(): Promise<void> {
         console.error(
           `[postPublisher] Failed to publish post ${post.id} (attempt ${newCount}/${MAX_RETRIES}): ${result.error}`,
         );
+
+        if (newCount >= MAX_RETRIES) {
+          await postRepository.update(post.id, { status: 'discarded' });
+          retryCounts.delete(post.id);
+          console.error(
+            `[postPublisher] Post ${post.id} discarded after ${MAX_RETRIES} failed attempts: ${result.error}`,
+          );
+        }
       }
     }
   } catch (err) {

--- a/web/src/hooks/useJobQueue.ts
+++ b/web/src/hooks/useJobQueue.ts
@@ -13,6 +13,7 @@ export type JobQueueStats = {
     scheduledAt: string;
     startedAt: string | null;
     completedAt: string | null;
+    error: string | null;
     createdAt: string;
   }>;
   upcomingJobs: Array<{
@@ -30,6 +31,7 @@ export type JobQueueStats = {
     status: string;
     scheduledAt: string;
     completedAt: string | null;
+    error: string | null;
     createdAt: string;
   }>;
   lastCompletedAt: string | null;

--- a/web/src/pages/JobQueuePage.tsx
+++ b/web/src/pages/JobQueuePage.tsx
@@ -1,11 +1,14 @@
+import { useState } from 'react';
 import Alert from '@mui/material/Alert';
 import Box from '@mui/material/Box';
 import Card from '@mui/material/Card';
 import CardContent from '@mui/material/CardContent';
 import Chip from '@mui/material/Chip';
+import Collapse from '@mui/material/Collapse';
 import Container from '@mui/material/Container';
 import CircularProgress from '@mui/material/CircularProgress';
 import Grid from '@mui/material/Grid';
+import IconButton from '@mui/material/IconButton';
 import Paper from '@mui/material/Paper';
 import Table from '@mui/material/Table';
 import TableBody from '@mui/material/TableBody';
@@ -14,6 +17,8 @@ import TableContainer from '@mui/material/TableContainer';
 import TableHead from '@mui/material/TableHead';
 import TableRow from '@mui/material/TableRow';
 import Typography from '@mui/material/Typography';
+import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
+import KeyboardArrowUpIcon from '@mui/icons-material/KeyboardArrowUp';
 import AppHeader from '../components/AppHeader';
 import { useJobQueue } from '../hooks/useJobQueue';
 
@@ -58,6 +63,12 @@ function computeDuration(startedAt: string | null, completedAt: string | null): 
   return `${minutes}m ${remainingSeconds}s`;
 }
 
+function getErrorFirstLine(error: string | null): string {
+  if (!error) return '';
+  const firstLine = error.split('\n')[0];
+  return firstLine.length > 120 ? firstLine.slice(0, 120) + '...' : firstLine;
+}
+
 function StatCard({
   title,
   value,
@@ -95,6 +106,194 @@ const statusChipColors: Record<string, 'default' | 'info' | 'success' | 'error' 
   completed: 'success',
   failed: 'error',
 };
+
+function ExpandableErrorRow({ error, colSpan }: { error: string | null; colSpan: number }) {
+  const [open, setOpen] = useState(false);
+
+  if (!error) return null;
+
+  const hasDetails = error.includes('\n');
+
+  return (
+    <>
+      <TableCell
+        sx={{
+          maxWidth: 300,
+          overflow: 'hidden',
+          textOverflow: 'ellipsis',
+          whiteSpace: 'nowrap',
+          cursor: hasDetails ? 'pointer' : 'default',
+        }}
+        onClick={hasDetails ? () => setOpen(!open) : undefined}
+      >
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+          {hasDetails && (
+            <IconButton size="small" sx={{ p: 0 }}>
+              {open ? (
+                <KeyboardArrowUpIcon fontSize="small" />
+              ) : (
+                <KeyboardArrowDownIcon fontSize="small" />
+              )}
+            </IconButton>
+          )}
+          <Typography variant="body2" color="error" noWrap>
+            {getErrorFirstLine(error)}
+          </Typography>
+        </Box>
+      </TableCell>
+    </>
+  );
+}
+
+function ErrorDetailCollapse({
+  error,
+  open,
+  colSpan,
+}: {
+  error: string | null;
+  open: boolean;
+  colSpan: number;
+}) {
+  if (!error || !error.includes('\n')) return null;
+
+  return (
+    <TableRow>
+      <TableCell colSpan={colSpan} sx={{ py: 0, borderBottom: open ? undefined : 'none' }}>
+        <Collapse in={open}>
+          <Box
+            sx={{
+              whiteSpace: 'pre-wrap',
+              fontFamily: 'monospace',
+              fontSize: '0.75rem',
+              backgroundColor: 'rgba(211, 47, 47, 0.04)',
+              p: 2,
+              my: 1,
+              borderRadius: 1,
+              maxHeight: 300,
+              overflow: 'auto',
+            }}
+          >
+            {error}
+          </Box>
+        </Collapse>
+      </TableCell>
+    </TableRow>
+  );
+}
+
+function RecentJobRow({
+  job,
+}: {
+  job: {
+    id: string;
+    botHandle: string;
+    status: string;
+    startedAt: string | null;
+    completedAt: string | null;
+    error: string | null;
+  };
+}) {
+  const [open, setOpen] = useState(false);
+  const isFailed = job.status === 'failed';
+  const hasDetails = !!job.error && job.error.includes('\n');
+
+  return (
+    <>
+      <TableRow sx={isFailed ? { bgcolor: 'rgba(211, 47, 47, 0.04)' } : undefined}>
+        <TableCell>{job.botHandle || '-'}</TableCell>
+        <TableCell>
+          <Chip label={job.status} color={statusChipColors[job.status] ?? 'default'} size="small" />
+        </TableCell>
+        <TableCell>{job.startedAt ? new Date(job.startedAt).toLocaleString() : '-'}</TableCell>
+        <TableCell>{job.completedAt ? new Date(job.completedAt).toLocaleString() : '-'}</TableCell>
+        <TableCell>{computeDuration(job.startedAt, job.completedAt)}</TableCell>
+        <TableCell
+          sx={{
+            maxWidth: 250,
+            cursor: hasDetails ? 'pointer' : 'default',
+          }}
+          onClick={hasDetails ? () => setOpen(!open) : undefined}
+        >
+          {job.error ? (
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+              {hasDetails && (
+                <IconButton size="small" sx={{ p: 0 }}>
+                  {open ? (
+                    <KeyboardArrowUpIcon fontSize="small" />
+                  ) : (
+                    <KeyboardArrowDownIcon fontSize="small" />
+                  )}
+                </IconButton>
+              )}
+              <Typography variant="body2" color="error" noWrap>
+                {getErrorFirstLine(job.error)}
+              </Typography>
+            </Box>
+          ) : (
+            '-'
+          )}
+        </TableCell>
+      </TableRow>
+      <ErrorDetailCollapse error={job.error} open={open} colSpan={6} />
+    </>
+  );
+}
+
+function ErrorJobRow({
+  job,
+}: {
+  job: {
+    id: string;
+    botHandle: string;
+    scheduledAt: string;
+    completedAt: string | null;
+    error: string | null;
+  };
+}) {
+  const [open, setOpen] = useState(false);
+  const hasDetails = !!job.error && job.error.includes('\n');
+
+  return (
+    <>
+      <TableRow sx={{ bgcolor: 'rgba(211, 47, 47, 0.04)' }}>
+        <TableCell>
+          <Chip label={job.botHandle || '-'} color="error" size="small" variant="outlined" />
+        </TableCell>
+        <TableCell>{new Date(job.scheduledAt).toLocaleString()}</TableCell>
+        <TableCell>{job.completedAt ? new Date(job.completedAt).toLocaleString() : '-'}</TableCell>
+        <TableCell
+          sx={{
+            maxWidth: 300,
+            cursor: hasDetails ? 'pointer' : 'default',
+          }}
+          onClick={hasDetails ? () => setOpen(!open) : undefined}
+        >
+          {job.error ? (
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+              {hasDetails && (
+                <IconButton size="small" sx={{ p: 0 }}>
+                  {open ? (
+                    <KeyboardArrowUpIcon fontSize="small" />
+                  ) : (
+                    <KeyboardArrowDownIcon fontSize="small" />
+                  )}
+                </IconButton>
+              )}
+              <Typography variant="body2" color="error" noWrap>
+                {getErrorFirstLine(job.error)}
+              </Typography>
+            </Box>
+          ) : (
+            <Typography variant="body2" color="text.secondary">
+              No error details
+            </Typography>
+          )}
+        </TableCell>
+      </TableRow>
+      <ErrorDetailCollapse error={job.error} open={open} colSpan={4} />
+    </>
+  );
+}
 
 export default function JobQueuePage() {
   const { data, isLoading, error } = useJobQueue();
@@ -201,7 +400,7 @@ export default function JobQueuePage() {
               ) : (
                 data.upcomingJobs.map((job) => (
                   <TableRow key={job.id}>
-                    <TableCell>@{job.botHandle}</TableCell>
+                    <TableCell>{job.botHandle || '-'}</TableCell>
                     <TableCell>{new Date(job.scheduledAt).toLocaleString()}</TableCell>
                     <TableCell>{new Date(job.createdAt).toLocaleString()}</TableCell>
                   </TableRow>
@@ -224,37 +423,20 @@ export default function JobQueuePage() {
                 <TableCell>Started At</TableCell>
                 <TableCell>Completed At</TableCell>
                 <TableCell>Duration</TableCell>
+                <TableCell>Error</TableCell>
               </TableRow>
             </TableHead>
             <TableBody>
               {data.recentJobs.length === 0 ? (
                 <TableRow>
-                  <TableCell colSpan={5} align="center">
+                  <TableCell colSpan={6} align="center">
                     <Typography variant="body2" color="text.secondary" sx={{ py: 2 }}>
                       No recent jobs
                     </Typography>
                   </TableCell>
                 </TableRow>
               ) : (
-                data.recentJobs.map((job) => (
-                  <TableRow key={job.id}>
-                    <TableCell>@{job.botHandle}</TableCell>
-                    <TableCell>
-                      <Chip
-                        label={job.status}
-                        color={statusChipColors[job.status] ?? 'default'}
-                        size="small"
-                      />
-                    </TableCell>
-                    <TableCell>
-                      {job.startedAt ? new Date(job.startedAt).toLocaleString() : '-'}
-                    </TableCell>
-                    <TableCell>
-                      {job.completedAt ? new Date(job.completedAt).toLocaleString() : '-'}
-                    </TableCell>
-                    <TableCell>{computeDuration(job.startedAt, job.completedAt)}</TableCell>
-                  </TableRow>
-                ))
+                data.recentJobs.map((job) => <RecentJobRow key={job.id} job={job} />)
               )}
             </TableBody>
           </Table>
@@ -269,28 +451,16 @@ export default function JobQueuePage() {
             <TableContainer component={Paper} sx={{ mb: 3 }}>
               <Table size="small">
                 <TableHead>
-                  <TableRow sx={{ bgcolor: 'error.50' }}>
+                  <TableRow sx={{ bgcolor: 'rgba(211, 47, 47, 0.08)' }}>
                     <TableCell>Bot</TableCell>
                     <TableCell>Scheduled At</TableCell>
                     <TableCell>Failed At</TableCell>
+                    <TableCell>Error</TableCell>
                   </TableRow>
                 </TableHead>
                 <TableBody>
                   {data.recentErrors.map((job) => (
-                    <TableRow key={job.id} sx={{ bgcolor: 'rgba(211, 47, 47, 0.04)' }}>
-                      <TableCell>
-                        <Chip
-                          label={`@${job.botHandle}`}
-                          color="error"
-                          size="small"
-                          variant="outlined"
-                        />
-                      </TableCell>
-                      <TableCell>{new Date(job.scheduledAt).toLocaleString()}</TableCell>
-                      <TableCell>
-                        {job.completedAt ? new Date(job.completedAt).toLocaleString() : '-'}
-                      </TableCell>
-                    </TableRow>
+                    <ErrorJobRow key={job.id} job={job} />
                   ))}
                 </TableBody>
               </Table>


### PR DESCRIPTION
## Summary
Fixes three critical bugs in the job queue system:

1. **Failed jobs now schedule the next run** — previously a failed job would leave the bot permanently stuck with no pending jobs. The next-job scheduling is now in a `finally` block.
2. **Error messages persisted to DB** — new `Job.error` text field stores error messages and stack traces. Previously errors were only logged to console.
3. **X token validation** — jobs skip content generation when bot has no X account connected, with clear error message.
4. **Posts discarded after max retries** — posts stuck in `scheduled` status after 3 failed publish attempts are now moved to `discarded`.
5. **Error details in UI** — Job Queue page shows error column with expandable stack traces (click to expand multi-line errors).

## Test plan
- [ ] Create bot without X connected → job fails with "X account not connected", next job still scheduled
- [ ] Job queue page shows error messages in Recent Jobs and Recent Errors tables
- [ ] Click on multi-line error → expands to show full stack trace
- [ ] Failed jobs don't block future scheduling

🤖 Generated with [Claude Code](https://claude.com/claude-code)