### PR TITLE
feat: worker activity log on job queue page

### DIFF
--- a/api/src/controllers/jobQueueController.ts
+++ b/api/src/controllers/jobQueueController.ts
@@ -1,5 +1,6 @@
 import { Request, Response, NextFunction } from 'express';
 import { prisma } from '../utils/prisma.js';
+import { getEntries as getActivityLog } from '../worker/activityLog.js';
 
 export const jobQueueController = {
   async getStats(req: Request, res: Response, next: NextFunction): Promise<void> {
@@ -102,6 +103,7 @@ export const jobQueueController = {
           recentErrors: recentErrors.map(formatJob),
           lastCompletedAt: lastCompleted?.completedAt ?? null,
           nextScheduledAt: nextScheduled?.scheduledAt ?? null,
+          activityLog: getActivityLog(),
         },
       });
     } catch (err) {

--- a/api/src/worker/activityLog.ts
+++ b/api/src/worker/activityLog.ts
@@ -1,0 +1,29 @@
+export type LogEntry = {
+  timestamp: string;
+  worker: 'jobWorker' | 'postPublisher' | 'staleLockRecovery';
+  message: string;
+  level: 'info' | 'warn' | 'error';
+};
+
+const MAX_ENTRIES = 100;
+const entries: LogEntry[] = [];
+
+export function log(
+  worker: LogEntry['worker'],
+  message: string,
+  level: LogEntry['level'] = 'info',
+): void {
+  entries.push({
+    timestamp: new Date().toISOString(),
+    worker,
+    message,
+    level,
+  });
+  if (entries.length > MAX_ENTRIES) {
+    entries.splice(0, entries.length - MAX_ENTRIES);
+  }
+}
+
+export function getEntries(): LogEntry[] {
+  return [...entries].reverse();
+}

--- a/api/src/worker/jobWorker.ts
+++ b/api/src/worker/jobWorker.ts
@@ -3,6 +3,7 @@ import { jobRepository } from '../repositories/jobRepository.js';
 import { postRepository } from '../repositories/postRepository.js';
 import { generateTweet } from '../services/aiService.js';
 import { computeNextScheduledAt } from '../services/scheduler.js';
+import { log } from './activityLog.js';
 
 const POLL_INTERVAL_MS = parseInt(process.env.WORKER_POLL_INTERVAL_MS || '30000', 10);
 
@@ -43,6 +44,7 @@ async function processJobs(): Promise<void> {
 
   try {
     const pendingJobs = await jobRepository.findPendingJobs(10);
+    log('jobWorker', `Poll: found ${pendingJobs.length} pending job(s)`);
 
     for (const job of pendingJobs) {
       const lockToken = uuidv4();
@@ -58,6 +60,7 @@ async function processJobs(): Promise<void> {
         // Check if X account is connected
         if (!bot.xAccessToken) {
           const errorMsg = 'X account not connected — skipping content generation';
+          log('jobWorker', `Job ${job.id}: ${errorMsg}`, 'warn');
           console.warn(`[jobWorker] Job ${job.id}: ${errorMsg}`);
           await jobRepository.markFailed(job.id, errorMsg);
           continue;
@@ -67,6 +70,7 @@ async function processJobs(): Promise<void> {
 
         if (!result.success) {
           const errorMsg = `AI generation failed: ${result.error}`;
+          log('jobWorker', `Job ${job.id}: ${errorMsg}`, 'error');
           console.error(`[jobWorker] Job ${job.id}: ${errorMsg}`);
           await jobRepository.markFailed(job.id, errorMsg);
           continue;
@@ -84,9 +88,15 @@ async function processJobs(): Promise<void> {
         });
 
         await jobRepository.markCompleted(job.id);
+        log('jobWorker', `Job ${job.id} completed — created ${postStatus} post`);
         console.log(`[jobWorker] Job ${job.id} completed successfully`);
       } catch (err) {
         const errorMsg = err instanceof Error ? `${err.message}\n${err.stack}` : String(err);
+        log(
+          'jobWorker',
+          `Job ${job.id} error: ${err instanceof Error ? err.message : String(err)}`,
+          'error',
+        );
         console.error(`[jobWorker] Error processing job ${job.id}:`, err);
         await jobRepository.markFailed(job.id, errorMsg);
       } finally {
@@ -99,6 +109,7 @@ async function processJobs(): Promise<void> {
       }
     }
   } catch (err) {
+    log('jobWorker', `Poll error: ${err instanceof Error ? err.message : String(err)}`, 'error');
     console.error('[jobWorker] Error polling for jobs:', err);
   } finally {
     running = false;

--- a/api/src/worker/postPublisher.ts
+++ b/api/src/worker/postPublisher.ts
@@ -1,5 +1,6 @@
 import { postRepository } from '../repositories/postRepository.js';
 import { publishTweet } from '../services/xApiService.js';
+import { log } from './activityLog.js';
 
 const POLL_INTERVAL_MS = parseInt(process.env.POST_PUBLISHER_POLL_INTERVAL_MS || '30000', 10);
 const MAX_RETRIES = 3;
@@ -16,6 +17,7 @@ async function publishPosts(): Promise<void> {
 
   try {
     const posts = await postRepository.findScheduledReady(20);
+    log('postPublisher', `Poll: found ${posts.length} post(s) ready to publish`);
 
     for (const post of posts) {
       // Skip posts that have exceeded retry limit
@@ -39,6 +41,7 @@ async function publishPosts(): Promise<void> {
         // Clean up retry counter on success
         retryCounts.delete(post.id);
 
+        log('postPublisher', `Published post ${post.id} as tweet ${result.tweetId ?? 'unknown'}`);
         console.log(
           `[postPublisher] Published post ${post.id} as tweet ${result.tweetId ?? 'unknown'}`,
         );
@@ -46,6 +49,11 @@ async function publishPosts(): Promise<void> {
         const newCount = currentRetries + 1;
         retryCounts.set(post.id, newCount);
 
+        log(
+          'postPublisher',
+          `Failed post ${post.id} (attempt ${newCount}/${MAX_RETRIES}): ${result.error}`,
+          'error',
+        );
         console.error(
           `[postPublisher] Failed to publish post ${post.id} (attempt ${newCount}/${MAX_RETRIES}): ${result.error}`,
         );
@@ -60,6 +68,11 @@ async function publishPosts(): Promise<void> {
       }
     }
   } catch (err) {
+    log(
+      'postPublisher',
+      `Poll error: ${err instanceof Error ? err.message : String(err)}`,
+      'error',
+    );
     console.error('[postPublisher] Error polling for scheduled posts:', err);
   } finally {
     running = false;

--- a/api/src/worker/staleLockRecovery.ts
+++ b/api/src/worker/staleLockRecovery.ts
@@ -1,4 +1,5 @@
 import { jobRepository } from '../repositories/jobRepository.js';
+import { log } from './activityLog.js';
 
 const RECOVERY_INTERVAL_MS = 5 * 60 * 1000; // 5 minutes
 const STALE_THRESHOLD_MINUTES = 10;
@@ -8,6 +9,8 @@ let intervalHandle: ReturnType<typeof setInterval> | null = null;
 async function recoverStaleLocks(): Promise<void> {
   try {
     const staleJobs = await jobRepository.findStaleLockedJobs(STALE_THRESHOLD_MINUTES);
+
+    log('staleLockRecovery', `Poll: found ${staleJobs.length} stale lock(s)`);
 
     if (staleJobs.length === 0) {
       return;
@@ -19,6 +22,7 @@ async function recoverStaleLocks(): Promise<void> {
 
     const result = await jobRepository.resetStaleLocks(STALE_THRESHOLD_MINUTES);
 
+    log('staleLockRecovery', `Recovered ${result.count} stale locked job(s)`, 'warn');
     console.log(`[staleLockRecovery] Recovered ${result.count} stale locked jobs`);
   } catch (err) {
     console.error('[staleLockRecovery] Error recovering stale locks:', err);

--- a/web/src/hooks/useJobQueue.ts
+++ b/web/src/hooks/useJobQueue.ts
@@ -36,6 +36,12 @@ export type JobQueueStats = {
   }>;
   lastCompletedAt: string | null;
   nextScheduledAt: string | null;
+  activityLog: Array<{
+    timestamp: string;
+    worker: string;
+    message: string;
+    level: 'info' | 'warn' | 'error';
+  }>;
 };
 
 type JobQueueStatsResponse = {

--- a/web/src/pages/JobQueuePage.tsx
+++ b/web/src/pages/JobQueuePage.tsx
@@ -467,6 +467,80 @@ export default function JobQueuePage() {
             </TableContainer>
           </>
         )}
+        {/* Worker Activity Log */}
+        <Typography variant="h6" gutterBottom>
+          Worker Activity Log
+        </Typography>
+        <TableContainer component={Paper} sx={{ mb: 3, maxHeight: 400 }}>
+          <Table size="small" stickyHeader>
+            <TableHead>
+              <TableRow>
+                <TableCell sx={{ width: 180 }}>Time</TableCell>
+                <TableCell sx={{ width: 140 }}>Worker</TableCell>
+                <TableCell>Message</TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {!data.activityLog || data.activityLog.length === 0 ? (
+                <TableRow>
+                  <TableCell colSpan={3} align="center">
+                    <Typography variant="body2" color="text.secondary" sx={{ py: 2 }}>
+                      No activity yet — workers may not have started
+                    </Typography>
+                  </TableCell>
+                </TableRow>
+              ) : (
+                data.activityLog.map((entry, i) => (
+                  <TableRow
+                    key={`${entry.timestamp}-${i}`}
+                    sx={{
+                      bgcolor:
+                        entry.level === 'error'
+                          ? 'rgba(211, 47, 47, 0.04)'
+                          : entry.level === 'warn'
+                            ? 'rgba(237, 108, 2, 0.04)'
+                            : undefined,
+                    }}
+                  >
+                    <TableCell
+                      sx={{ fontFamily: 'monospace', fontSize: '0.75rem', whiteSpace: 'nowrap' }}
+                    >
+                      {new Date(entry.timestamp).toLocaleTimeString()}
+                    </TableCell>
+                    <TableCell>
+                      <Chip
+                        label={entry.worker}
+                        size="small"
+                        variant="outlined"
+                        color={
+                          entry.worker === 'jobWorker'
+                            ? 'primary'
+                            : entry.worker === 'postPublisher'
+                              ? 'success'
+                              : 'default'
+                        }
+                      />
+                    </TableCell>
+                    <TableCell
+                      sx={{
+                        fontFamily: 'monospace',
+                        fontSize: '0.75rem',
+                        color:
+                          entry.level === 'error'
+                            ? 'error.main'
+                            : entry.level === 'warn'
+                              ? 'warning.main'
+                              : 'text.primary',
+                      }}
+                    >
+                      {entry.message}
+                    </TableCell>
+                  </TableRow>
+                ))
+              )}
+            </TableBody>
+          </Table>
+        </TableContainer>
       </Container>
     </>
   );


### PR DESCRIPTION
## Summary
- New in-memory activity log (last 100 entries) tracking all worker polls and actions
- All three workers (jobWorker, postPublisher, staleLockRecovery) write to the log on every poll cycle
- Log exposed via `/api/jobs/stats` response and displayed on the Job Queue page
- Scrollable table with sticky header, color-coded by log level and worker type
- Auto-refreshes every 30s with the existing poll

## What you'll see
- Every 30s: `jobWorker` "Poll: found N pending job(s)"
- Every 30s: `postPublisher` "Poll: found N post(s) ready to publish"
- Every 5m: `staleLockRecovery` "Poll: found N stale lock(s)"
- Plus job completions, failures, publish successes, and errors
- If the log is empty after deploy, workers aren't starting

## Test plan
- [ ] Deploy → visit /jobs → see activity log populating every 30s
- [ ] Errors show in red, warnings in orange
- [ ] Worker chips color-coded (jobWorker=blue, postPublisher=green, staleLockRecovery=grey)

🤖 Generated with [Claude Code](https://claude.com/claude-code)