### PR TITLE
fix: add startup and poll logging to all workers

### DIFF
--- a/api/src/worker/jobWorker.ts
+++ b/api/src/worker/jobWorker.ts
@@ -45,6 +45,7 @@ async function processJobs(): Promise<void> {
   try {
     const pendingJobs = await jobRepository.findPendingJobs(10);
     log('jobWorker', `Poll: found ${pendingJobs.length} pending job(s)`);
+    console.log(`[jobWorker] Poll: found ${pendingJobs.length} pending job(s)`);
 
     for (const job of pendingJobs) {
       const lockToken = uuidv4();
@@ -117,6 +118,7 @@ async function processJobs(): Promise<void> {
 }
 
 export function start(): void {
+  log('jobWorker', `Starting with poll interval ${POLL_INTERVAL_MS}ms`);
   console.log(`[jobWorker] Starting with poll interval ${POLL_INTERVAL_MS}ms`);
   // Run immediately on start
   void processJobs();

--- a/api/src/worker/postPublisher.ts
+++ b/api/src/worker/postPublisher.ts
@@ -18,6 +18,7 @@ async function publishPosts(): Promise<void> {
   try {
     const posts = await postRepository.findScheduledReady(20);
     log('postPublisher', `Poll: found ${posts.length} post(s) ready to publish`);
+    console.log(`[postPublisher] Poll: found ${posts.length} post(s) ready to publish`);
 
     for (const post of posts) {
       // Skip posts that have exceeded retry limit
@@ -81,6 +82,7 @@ async function publishPosts(): Promise<void> {
 
 export function start(pollIntervalMs?: number): void {
   const interval = pollIntervalMs ?? POLL_INTERVAL_MS;
+  log('postPublisher', `Starting with poll interval ${interval}ms`);
   console.log(`[postPublisher] Starting with poll interval ${interval}ms`);
   void publishPosts();
   intervalHandle = setInterval(() => void publishPosts(), interval);

--- a/api/src/worker/staleLockRecovery.ts
+++ b/api/src/worker/staleLockRecovery.ts
@@ -30,6 +30,7 @@ async function recoverStaleLocks(): Promise<void> {
 }
 
 export function start(): void {
+  log('staleLockRecovery', 'Starting stale lock recovery');
   console.log('[staleLockRecovery] Starting stale lock recovery');
   // Run immediately on start
   void recoverStaleLocks();


### PR DESCRIPTION
## Summary
- All 3 workers now log their startup to both the activity log (UI) and console (Render logs)
- Poll cycles also log to console so you can see them in Render's log viewer
- After deploy you should see in Render logs:
  ```
  [jobWorker] Starting with poll interval 30000ms
  [postPublisher] Starting with poll interval 30000ms
  [staleLockRecovery] Starting stale lock recovery
  [jobWorker] Poll: found 0 pending job(s)
  [postPublisher] Poll: found 0 post(s) ready to publish
  ```

🤖 Generated with [Claude Code](https://claude.com/claude-code)