### PR TITLE
feat: add job reconciliation for bots with no pending work

### DIFF
--- a/api/src/repositories/jobRepository.ts
+++ b/api/src/repositories/jobRepository.ts
@@ -123,4 +123,25 @@ export const jobRepository = {
       },
     });
   },
+
+  async findActiveBotsWithoutPendingJobs() {
+    return prisma.bot.findMany({
+      where: {
+        active: true,
+        user: { archivedAt: null },
+        jobs: {
+          none: {
+            status: { in: ['pending', 'locked'] },
+          },
+        },
+      },
+      include: {
+        jobs: {
+          where: { status: 'completed' },
+          orderBy: { completedAt: 'desc' },
+          take: 1,
+        },
+      },
+    });
+  },
 };

--- a/api/src/worker/jobWorker.ts
+++ b/api/src/worker/jobWorker.ts
@@ -38,11 +38,66 @@ async function scheduleNextJob(bot: {
   );
 }
 
+async function reconcileBots(): Promise<void> {
+  try {
+    const botsWithoutJobs = await jobRepository.findActiveBotsWithoutPendingJobs();
+
+    if (botsWithoutJobs.length === 0) return;
+
+    log('jobWorker', `Reconciliation: ${botsWithoutJobs.length} bot(s) have no pending jobs`);
+    console.log(
+      `[jobWorker] Reconciliation: ${botsWithoutJobs.length} bot(s) need new jobs`,
+    );
+
+    for (const bot of botsWithoutJobs) {
+      try {
+        const lastCompleted = bot.jobs[0]?.completedAt ?? null;
+        const baseTime = lastCompleted ?? new Date();
+
+        const nextScheduledAt = computeNextScheduledAt(
+          {
+            postsPerDay: bot.postsPerDay,
+            minIntervalHours: bot.minIntervalHours,
+            preferredHoursStart: bot.preferredHoursStart,
+            preferredHoursEnd: bot.preferredHoursEnd,
+          },
+          baseTime,
+        );
+
+        await jobRepository.create({
+          botId: bot.id,
+          scheduledAt: nextScheduledAt,
+          status: 'pending',
+        });
+
+        log(
+          'jobWorker',
+          `Reconciliation: created job for bot ${bot.id} scheduled at ${nextScheduledAt.toISOString()}`,
+        );
+        console.log(
+          `[jobWorker] Reconciliation: created job for bot ${bot.id} at ${nextScheduledAt.toISOString()}`,
+        );
+      } catch (err) {
+        console.error(`[jobWorker] Reconciliation: failed to create job for bot ${bot.id}:`, err);
+      }
+    }
+  } catch (err) {
+    log(
+      'jobWorker',
+      `Reconciliation error: ${err instanceof Error ? err.message : String(err)}`,
+      'error',
+    );
+    console.error('[jobWorker] Reconciliation error:', err);
+  }
+}
+
 async function processJobs(): Promise<void> {
   if (running) return;
   running = true;
 
   try {
+    await reconcileBots();
+
     const pendingJobs = await jobRepository.findPendingJobs(10);
     log('jobWorker', `Poll: found ${pendingJobs.length} pending job(s)`);
     console.log(`[jobWorker] Poll: found ${pendingJobs.length} pending job(s)`);


### PR DESCRIPTION
## Summary
- Adds a `reconcileBots()` step that runs at the start of each jobWorker poll cycle
- Finds all active bots (with non-archived users) that have zero pending or locked jobs
- Creates a new pending job for each using their scheduling config and last completed job time
- Logs all reconciliation actions to the worker activity log (visible on job queue page)

## Test plan
- [ ] Deploy and verify bots that previously had 0 pending jobs now get new jobs created
- [ ] Check job queue page shows reconciliation entries in the activity log
- [ ] Verify bots with existing pending/locked jobs are not affected
- [ ] Verify archived users' bots and inactive bots are excluded

🤖 Generated with [Claude Code](https://claude.com/claude-code)