### PR TITLE
feat: add ability to cancel scheduled jobs

### DIFF
--- a/api/src/controllers/jobQueueController.ts
+++ b/api/src/controllers/jobQueueController.ts
@@ -1,8 +1,27 @@
 import { Request, Response, NextFunction } from 'express';
 import { prisma } from '../utils/prisma.js';
+import { jobRepository } from '../repositories/jobRepository.js';
 import { getEntries as getActivityLog } from '../worker/activityLog.js';
+import { log } from '../worker/activityLog.js';
 
 export const jobQueueController = {
+  async cancelJob(req: Request<{ id: string }>, res: Response, next: NextFunction): Promise<void> {
+    try {
+      const { id } = req.params;
+      const result = await jobRepository.cancel(id);
+
+      if (result.count === 0) {
+        res.status(404).json({ error: 'Job not found or not cancellable' });
+        return;
+      }
+
+      log('jobWorker', `Job ${id} cancelled by user`);
+      res.status(200).json({ data: { id, status: 'cancelled' } });
+    } catch (err) {
+      next(err);
+    }
+  },
+
   async getStats(req: Request, res: Response, next: NextFunction): Promise<void> {
     try {
       const [
@@ -57,6 +76,7 @@ export const jobQueueController = {
         locked: 0,
         completed: 0,
         failed: 0,
+        cancelled: 0,
       };
       for (const row of jobCountsByStatus) {
         jobCounts[row.status] = row._count.status;

--- a/api/src/repositories/jobRepository.ts
+++ b/api/src/repositories/jobRepository.ts
@@ -99,6 +99,19 @@ export const jobRepository = {
     });
   },
 
+  async cancel(jobId: string) {
+    return prisma.job.updateMany({
+      where: {
+        id: jobId,
+        status: { in: ['pending', 'locked'] },
+      },
+      data: {
+        status: 'cancelled',
+        completedAt: new Date(),
+      },
+    });
+  },
+
   async findStaleLockedJobs(staleMinutes = 10) {
     const cutoff = new Date(Date.now() - staleMinutes * 60 * 1000);
     return prisma.job.findMany({

--- a/api/src/routes/jobQueueRoutes.ts
+++ b/api/src/routes/jobQueueRoutes.ts
@@ -7,5 +7,6 @@ const router = Router();
 router.use(authMiddleware);
 
 router.get('/stats', jobQueueController.getStats);
+router.post('/:id/cancel', jobQueueController.cancelJob);
 
 export default router;

--- a/web/src/hooks/useJobQueue.ts
+++ b/web/src/hooks/useJobQueue.ts
@@ -1,9 +1,9 @@
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { apiClient } from '../lib/apiClient';
 import { queryKeys } from '../lib/queryKeys';
 
 export type JobQueueStats = {
-  jobCounts: { pending: number; locked: number; completed: number; failed: number };
+  jobCounts: { pending: number; locked: number; completed: number; failed: number; cancelled: number };
   postCounts: { draft: number; scheduled: number; published: number; discarded: number };
   recentJobs: Array<{
     id: string;
@@ -56,5 +56,17 @@ export function useJobQueue() {
       return response.data.data;
     },
     refetchInterval: 30000,
+  });
+}
+
+export function useCancelJob() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (jobId: string) => {
+      await apiClient.post(`/jobs/${jobId}/cancel`);
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.jobs.stats });
+    },
   });
 }

--- a/web/src/pages/JobQueuePage.tsx
+++ b/web/src/pages/JobQueuePage.tsx
@@ -19,8 +19,10 @@ import TableRow from '@mui/material/TableRow';
 import Typography from '@mui/material/Typography';
 import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
 import KeyboardArrowUpIcon from '@mui/icons-material/KeyboardArrowUp';
+import Button from '@mui/material/Button';
+import CancelIcon from '@mui/icons-material/Cancel';
 import AppHeader from '../components/AppHeader';
-import { useJobQueue } from '../hooks/useJobQueue';
+import { useJobQueue, useCancelJob } from '../hooks/useJobQueue';
 
 function formatRelativeTime(dateStr: string | null): string {
   if (!dateStr) return 'N/A';
@@ -105,6 +107,7 @@ const statusChipColors: Record<string, 'default' | 'info' | 'success' | 'error' 
   locked: 'info',
   completed: 'success',
   failed: 'error',
+  cancelled: 'warning',
 };
 
 function ExpandableErrorRow({ error, colSpan }: { error: string | null; colSpan: number }) {
@@ -297,6 +300,7 @@ function ErrorJobRow({
 
 export default function JobQueuePage() {
   const { data, isLoading, error } = useJobQueue();
+  const cancelJob = useCancelJob();
 
   if (isLoading) {
     return (
@@ -354,6 +358,11 @@ export default function JobQueuePage() {
           <Grid item xs={6} sm={3}>
             <StatCard title="Failed" value={data.jobCounts.failed} color="error" />
           </Grid>
+          {data.jobCounts.cancelled > 0 && (
+            <Grid item xs={6} sm={3}>
+              <StatCard title="Cancelled" value={data.jobCounts.cancelled} color="warning" />
+            </Grid>
+          )}
         </Grid>
 
         {/* Post Counts */}
@@ -386,12 +395,13 @@ export default function JobQueuePage() {
                 <TableCell>Bot</TableCell>
                 <TableCell>Scheduled At</TableCell>
                 <TableCell>Created At</TableCell>
+                <TableCell align="right">Actions</TableCell>
               </TableRow>
             </TableHead>
             <TableBody>
               {data.upcomingJobs.length === 0 ? (
                 <TableRow>
-                  <TableCell colSpan={3} align="center">
+                  <TableCell colSpan={4} align="center">
                     <Typography variant="body2" color="text.secondary" sx={{ py: 2 }}>
                       No upcoming jobs
                     </Typography>
@@ -403,6 +413,17 @@ export default function JobQueuePage() {
                     <TableCell>{job.botHandle || '-'}</TableCell>
                     <TableCell>{new Date(job.scheduledAt).toLocaleString()}</TableCell>
                     <TableCell>{new Date(job.createdAt).toLocaleString()}</TableCell>
+                    <TableCell align="right">
+                      <Button
+                        size="small"
+                        color="warning"
+                        startIcon={<CancelIcon />}
+                        onClick={() => cancelJob.mutate(job.id)}
+                        disabled={cancelJob.isPending}
+                      >
+                        Cancel
+                      </Button>
+                    </TableCell>
                   </TableRow>
                 ))
               )}


### PR DESCRIPTION
## Summary
- Adds `POST /jobs/:id/cancel` API endpoint that sets pending/locked jobs to cancelled status
- Adds Cancel button on each row in the Upcoming Jobs table on the job queue page
- Shows cancelled job count in stats when > 0
- Cancelled jobs are logged in the worker activity log
- The existing reconciliation step will detect the bot has no pending jobs and schedule a new one

## Test plan
- [ ] Click Cancel on an upcoming job — verify it disappears from upcoming and count updates
- [ ] Verify a new job is automatically created for that bot on the next poll cycle (~30s)
- [ ] Verify cancelled count appears in job stats cards

🤖 Generated with [Claude Code](https://claude.com/claude-code)