### PR TITLE
feat: add favicon

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <title>X Bot Platform</title>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />

--- a/web/public/favicon.svg
+++ b/web/public/favicon.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect width="64" height="64" rx="14" fill="#000"/>
+  <g transform="translate(10, 12)">
+    <!-- Robot head -->
+    <rect x="6" y="10" width="32" height="26" rx="5" fill="#1d9bf0"/>
+    <!-- Antenna -->
+    <line x1="22" y1="10" x2="22" y2="3" stroke="#1d9bf0" stroke-width="2.5" stroke-linecap="round"/>
+    <circle cx="22" cy="2" r="2.5" fill="#1d9bf0"/>
+    <!-- Eyes -->
+    <circle cx="15" cy="22" r="4" fill="#000"/>
+    <circle cx="29" cy="22" r="4" fill="#000"/>
+    <circle cx="16" cy="21" r="1.5" fill="#fff"/>
+    <circle cx="30" cy="21" r="1.5" fill="#fff"/>
+    <!-- Mouth / X shape -->
+    <line x1="17" y1="30" x2="21" y2="33" stroke="#000" stroke-width="2" stroke-linecap="round"/>
+    <line x1="21" y1="30" x2="17" y2="33" stroke="#000" stroke-width="2" stroke-linecap="round"/>
+    <line x1="23" y1="30" x2="27" y2="33" stroke="#000" stroke-width="2" stroke-linecap="round"/>
+    <line x1="27" y1="30" x2="23" y2="33" stroke="#000" stroke-width="2" stroke-linecap="round"/>
+    <!-- Ears -->
+    <rect x="1" y="18" width="5" height="8" rx="2" fill="#1d9bf0"/>
+    <rect x="38" y="18" width="5" height="8" rx="2" fill="#1d9bf0"/>
+  </g>
+</svg>


### PR DESCRIPTION
## Summary
- Adds SVG favicon: blue robot head on black rounded square, with X-shaped mouth
- References X/Twitter brand color (#1d9bf0) for quick recognition
- SVG format renders crisply at any tab size

## Test plan
- [ ] Open the app in a browser — verify favicon appears in the tab
- [ ] Check it's distinguishable at small sizes

🤖 Generated with [Claude Code](https://claude.com/claude-code)