### PR TITLE
feat: catch-up scheduling when bot is behind on post frequency

### DIFF
--- a/api/src/repositories/postRepository.ts
+++ b/api/src/repositories/postRepository.ts
@@ -87,6 +87,17 @@ export const postRepository = {
     });
   },
 
+  async countRecentByBot(botId: string, hoursBack = 24) {
+    const since = new Date(Date.now() - hoursBack * 60 * 60 * 1000);
+    return prisma.post.count({
+      where: {
+        botId,
+        createdAt: { gte: since },
+        status: { in: ['draft', 'scheduled', 'published'] },
+      },
+    });
+  },
+
   async updateStatus(
     id: string,
     status: string,

--- a/api/src/worker/jobWorker.ts
+++ b/api/src/worker/jobWorker.ts
@@ -6,6 +6,7 @@ import { computeNextScheduledAt } from '../services/scheduler.js';
 import { log } from './activityLog.js';
 
 const POLL_INTERVAL_MS = parseInt(process.env.WORKER_POLL_INTERVAL_MS || '30000', 10);
+const CATCHUP_MINUTES = 15;
 
 let intervalHandle: ReturnType<typeof setInterval> | null = null;
 let running = false;
@@ -51,18 +52,32 @@ async function reconcileBots(): Promise<void> {
 
     for (const bot of botsWithoutJobs) {
       try {
-        const lastCompleted = bot.jobs[0]?.completedAt ?? null;
-        const baseTime = lastCompleted ?? new Date();
+        const recentPostCount = await postRepository.countRecentByBot(bot.id, 24);
+        const isBehind = recentPostCount < bot.postsPerDay;
 
-        const nextScheduledAt = computeNextScheduledAt(
-          {
-            postsPerDay: bot.postsPerDay,
-            minIntervalHours: bot.minIntervalHours,
-            preferredHoursStart: bot.preferredHoursStart,
-            preferredHoursEnd: bot.preferredHoursEnd,
-          },
-          baseTime,
-        );
+        let nextScheduledAt: Date;
+
+        if (isBehind) {
+          // Behind on frequency — schedule catch-up within 15 minutes
+          const jitterMs = Math.floor(Math.random() * CATCHUP_MINUTES * 60 * 1000);
+          nextScheduledAt = new Date(Date.now() + jitterMs);
+          log(
+            'jobWorker',
+            `Reconciliation: bot ${bot.id} behind schedule (${recentPostCount}/${bot.postsPerDay} posts in 24h), catch-up in ${Math.round(jitterMs / 60000)}m`,
+          );
+        } else {
+          const lastCompleted = bot.jobs[0]?.completedAt ?? null;
+          const baseTime = lastCompleted ?? new Date();
+          nextScheduledAt = computeNextScheduledAt(
+            {
+              postsPerDay: bot.postsPerDay,
+              minIntervalHours: bot.minIntervalHours,
+              preferredHoursStart: bot.preferredHoursStart,
+              preferredHoursEnd: bot.preferredHoursEnd,
+            },
+            baseTime,
+          );
+        }
 
         await jobRepository.create({
           botId: bot.id,


### PR DESCRIPTION
## Summary
- Reconciliation now counts posts (draft/scheduled/published) created in the last 24h per bot
- Compares against `postsPerDay` config to detect if bot is behind schedule
- If behind: schedules next job within 0-15 minutes (random jitter) for quick catch-up
- If on track: uses normal `computeNextScheduledAt` interval
- Adds `postRepository.countRecentByBot()` helper method

## Test plan
- [ ] Bot with 3 postsPerDay and 0 recent posts gets a job scheduled within 15 minutes
- [ ] Bot with 3 postsPerDay and 3+ recent posts gets normal interval scheduling
- [ ] Activity log shows catch-up messages with post count details
- [ ] After catch-up job completes, next reconciliation re-evaluates whether still behind

🤖 Generated with [Claude Code](https://claude.com/claude-code)