### PR TITLE
feat: rate limit publishing to max 2 posts per hour per bot

### DIFF
--- a/api/src/repositories/postRepository.ts
+++ b/api/src/repositories/postRepository.ts
@@ -87,6 +87,16 @@ export const postRepository = {
     });
   },
 
+  async countPublishedByBotSince(botId: string, since: Date) {
+    return prisma.post.count({
+      where: {
+        botId,
+        status: 'published',
+        publishedAt: { gte: since },
+      },
+    });
+  },
+
   async countRecentByBot(botId: string, hoursBack = 24) {
     const since = new Date(Date.now() - hoursBack * 60 * 60 * 1000);
     return prisma.post.count({

--- a/api/src/worker/postPublisher.ts
+++ b/api/src/worker/postPublisher.ts
@@ -4,6 +4,8 @@ import { log } from './activityLog.js';
 
 const POLL_INTERVAL_MS = parseInt(process.env.POST_PUBLISHER_POLL_INTERVAL_MS || '30000', 10);
 const MAX_RETRIES = 3;
+const MAX_POSTS_PER_HOUR = 2;
+const RESCHEDULE_DELAY_MS = 30 * 60 * 1000; // 30 minutes
 
 let intervalHandle: ReturnType<typeof setInterval> | null = null;
 let running = false;
@@ -31,6 +33,21 @@ async function publishPosts(): Promise<void> {
       }
 
       const bot = post.bot;
+
+      // Rate limit: max 2 posts per hour per bot
+      const oneHourAgo = new Date(Date.now() - 60 * 60 * 1000);
+      const publishedLastHour = await postRepository.countPublishedByBotSince(bot.id, oneHourAgo);
+      if (publishedLastHour >= MAX_POSTS_PER_HOUR) {
+        const newScheduledAt = new Date(Date.now() + RESCHEDULE_DELAY_MS);
+        await postRepository.update(post.id, { scheduledAt: newScheduledAt });
+        log(
+          'postPublisher',
+          `Rate limit: bot ${bot.id} has ${publishedLastHour} posts in last hour (max ${MAX_POSTS_PER_HOUR}), rescheduled post ${post.id} to ${newScheduledAt.toISOString()}`,
+          'warn',
+        );
+        continue;
+      }
+
       const result = await publishTweet(post.content, bot.xAccessToken, bot.xAccessSecret, bot.id);
 
       if (result.success) {


### PR DESCRIPTION
## Summary
- Before publishing, checks how many posts were published for that bot in the last hour
- If >= 2, skips publishing and reschedules the post 30 minutes later
- Logs rate limit events as warnings in the worker activity log
- Adds `postRepository.countPublishedByBotSince()` helper

## Test plan
- [ ] Bot with 0 published posts in last hour publishes normally
- [ ] Bot with 2+ published posts in last hour has its post rescheduled 30 min later
- [ ] Activity log shows rate limit warning with post count details
- [ ] Rescheduled post gets picked up and published on the next eligible poll

🤖 Generated with [Claude Code](https://claude.com/claude-code)