### PR TITLE
feat: add bot sharing between users

### DIFF
--- a/api/prisma/migrations/20260314000000_add_bot_share/migration.sql
+++ b/api/prisma/migrations/20260314000000_add_bot_share/migration.sql
@@ -1,0 +1,18 @@
+-- CreateTable
+CREATE TABLE "BotShare" (
+    "id" UUID NOT NULL DEFAULT gen_random_uuid(),
+    "botId" UUID NOT NULL,
+    "userId" UUID NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "BotShare_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "BotShare_botId_userId_key" ON "BotShare"("botId", "userId");
+
+-- AddForeignKey
+ALTER TABLE "BotShare" ADD CONSTRAINT "BotShare_botId_fkey" FOREIGN KEY ("botId") REFERENCES "Bot"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "BotShare" ADD CONSTRAINT "BotShare_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -15,7 +15,8 @@ model User {
   archivedAt   DateTime?
   createdAt    DateTime @default(now())
 
-  bots Bot[]
+  bots      Bot[]
+  botShares BotShare[]
 }
 
 model Bot {
@@ -33,9 +34,22 @@ model Bot {
   active              Boolean  @default(true)
   createdAt           DateTime @default(now())
 
-  user  User   @relation(fields: [userId], references: [id])
-  posts Post[]
-  jobs  Job[]
+  user   User       @relation(fields: [userId], references: [id])
+  posts  Post[]
+  jobs   Job[]
+  shares BotShare[]
+}
+
+model BotShare {
+  id        String   @id @default(uuid()) @db.Uuid
+  botId     String   @db.Uuid
+  userId    String   @db.Uuid
+  createdAt DateTime @default(now())
+
+  bot  Bot  @relation(fields: [botId], references: [id])
+  user User @relation(fields: [userId], references: [id])
+
+  @@unique([botId, userId])
 }
 
 model Post {

--- a/api/src/controllers/botShareController.ts
+++ b/api/src/controllers/botShareController.ts
@@ -1,0 +1,56 @@
+import { Request, Response, NextFunction } from 'express';
+import { z } from 'zod';
+import { botShareService } from '../services/botShareService.js';
+import { uuidSchema, emailSchema } from '../utils/validation.js';
+
+const botIdParamSchema = z.object({
+  id: uuidSchema,
+});
+
+const shareParamsSchema = z.object({
+  id: uuidSchema,
+  userId: uuidSchema,
+});
+
+const shareBotSchema = z.object({
+  email: emailSchema,
+});
+
+export const botShareController = {
+  async create(req: Request, res: Response, next: NextFunction): Promise<void> {
+    try {
+      const userId = req.userId!;
+      const { id: botId } = botIdParamSchema.parse(req.params);
+      const { email } = shareBotSchema.parse(req.body);
+      const share = await botShareService.shareBot(botId, userId, email);
+
+      res.status(201).json({ data: share });
+    } catch (err) {
+      next(err);
+    }
+  },
+
+  async remove(req: Request, res: Response, next: NextFunction): Promise<void> {
+    try {
+      const userId = req.userId!;
+      const { id: botId, userId: targetUserId } = shareParamsSchema.parse(req.params);
+      await botShareService.unshareBot(botId, userId, targetUserId);
+
+      res.status(204).send();
+    } catch (err) {
+      next(err);
+    }
+  },
+
+  async list(req: Request, res: Response, next: NextFunction): Promise<void> {
+    try {
+      const userId = req.userId!;
+      const { id: botId } = botIdParamSchema.parse(req.params);
+      const shares = await botShareService.listShares(botId, userId);
+
+      res.status(200).json({ data: shares });
+    } catch (err) {
+      next(err);
+    }
+  },
+};

--- a/api/src/repositories/botRepository.ts
+++ b/api/src/repositories/botRepository.ts
@@ -52,15 +52,21 @@ export const botRepository = {
   },
 
   async findByUserId(userId: string, page: number, pageSize: number) {
+    const where = {
+      OR: [{ userId }, { shares: { some: { userId } } }],
+    };
     const [bots, total] = await Promise.all([
       prisma.bot.findMany({
-        where: { userId },
-        select: botSelect,
+        where,
+        select: {
+          ...botSelect,
+          user: { select: { id: true, email: true, name: true } },
+        },
         skip: (page - 1) * pageSize,
         take: pageSize,
         orderBy: { createdAt: 'desc' },
       }),
-      prisma.bot.count({ where: { userId } }),
+      prisma.bot.count({ where }),
     ]);
     return { bots, total };
   },

--- a/api/src/repositories/botShareRepository.ts
+++ b/api/src/repositories/botShareRepository.ts
@@ -1,0 +1,74 @@
+import { prisma } from '../utils/prisma.js';
+
+export const botShareRepository = {
+  async create(botId: string, userId: string) {
+    return prisma.botShare.create({
+      data: { botId, userId },
+      select: {
+        id: true,
+        botId: true,
+        userId: true,
+        createdAt: true,
+        user: {
+          select: { id: true, email: true, name: true },
+        },
+      },
+    });
+  },
+
+  async delete(botId: string, userId: string) {
+    return prisma.botShare.delete({
+      where: {
+        botId_userId: { botId, userId },
+      },
+    });
+  },
+
+  async findByBotId(botId: string) {
+    return prisma.botShare.findMany({
+      where: { botId },
+      select: {
+        id: true,
+        botId: true,
+        userId: true,
+        createdAt: true,
+        user: {
+          select: { id: true, email: true, name: true },
+        },
+      },
+      orderBy: { createdAt: 'desc' },
+    });
+  },
+
+  async findByBotIdAndUserId(botId: string, userId: string) {
+    return prisma.botShare.findUnique({
+      where: {
+        botId_userId: { botId, userId },
+      },
+    });
+  },
+
+  async findSharedBotsByUserId(userId: string) {
+    return prisma.botShare.findMany({
+      where: { userId },
+      select: {
+        bot: {
+          select: {
+            id: true,
+            userId: true,
+            xAccountHandle: true,
+            prompt: true,
+            postMode: true,
+            postsPerDay: true,
+            minIntervalHours: true,
+            preferredHoursStart: true,
+            preferredHoursEnd: true,
+            active: true,
+            createdAt: true,
+          },
+        },
+      },
+      orderBy: { createdAt: 'desc' },
+    });
+  },
+};

--- a/api/src/routes/botRoutes.ts
+++ b/api/src/routes/botRoutes.ts
@@ -1,5 +1,6 @@
 import { Router } from 'express';
 import { botController } from '../controllers/botController.js';
+import { botShareController } from '../controllers/botShareController.js';
 import { authMiddleware } from '../middleware/auth.js';
 
 const router = Router();
@@ -11,5 +12,10 @@ router.post('/', botController.create);
 router.get('/', botController.list);
 router.get('/:id', botController.getById);
 router.patch('/:id', botController.update);
+
+// Share routes
+router.post('/:id/shares', botShareController.create);
+router.get('/:id/shares', botShareController.list);
+router.delete('/:id/shares/:userId', botShareController.remove);
 
 export default router;

--- a/api/src/services/botService.ts
+++ b/api/src/services/botService.ts
@@ -1,6 +1,7 @@
 import { Prisma } from '@prisma/client';
 import { prisma } from '../utils/prisma.js';
 import { botRepository } from '../repositories/botRepository.js';
+import { botShareRepository } from '../repositories/botShareRepository.js';
 import { jobRepository } from '../repositories/jobRepository.js';
 import { NotFoundError, ForbiddenError } from '../utils/errors.js';
 
@@ -72,7 +73,10 @@ export const botService = {
       throw new NotFoundError('Bot not found');
     }
     if (bot.userId !== userId) {
-      throw new ForbiddenError('You do not have access to this bot');
+      const share = await botShareRepository.findByBotIdAndUserId(botId, userId);
+      if (!share) {
+        throw new ForbiddenError('You do not have access to this bot');
+      }
     }
     return bot;
   },
@@ -83,7 +87,10 @@ export const botService = {
       throw new NotFoundError('Bot not found');
     }
     if (bot.userId !== userId) {
-      throw new ForbiddenError('You do not have access to this bot');
+      const share = await botShareRepository.findByBotIdAndUserId(botId, userId);
+      if (!share) {
+        throw new ForbiddenError('You do not have access to this bot');
+      }
     }
     return botRepository.update(botId, input);
   },

--- a/api/src/services/botShareService.ts
+++ b/api/src/services/botShareService.ts
@@ -1,0 +1,69 @@
+import { prisma } from '../utils/prisma.js';
+import { botRepository } from '../repositories/botRepository.js';
+import { botShareRepository } from '../repositories/botShareRepository.js';
+import { NotFoundError, ForbiddenError, ConflictError } from '../utils/errors.js';
+
+export const botShareService = {
+  async shareBot(botId: string, ownerUserId: string, targetEmail: string) {
+    const bot = await botRepository.findById(botId);
+    if (!bot) {
+      throw new NotFoundError('Bot not found');
+    }
+    if (bot.userId !== ownerUserId) {
+      throw new ForbiddenError('Only the bot owner can share this bot');
+    }
+
+    const targetUser = await prisma.user.findUnique({
+      where: { email: targetEmail },
+      select: { id: true, email: true, name: true },
+    });
+    if (!targetUser) {
+      throw new NotFoundError('User not found with that email');
+    }
+
+    if (targetUser.id === ownerUserId) {
+      throw new ConflictError('Cannot share a bot with yourself');
+    }
+
+    const existing = await botShareRepository.findByBotIdAndUserId(botId, targetUser.id);
+    if (existing) {
+      throw new ConflictError('Bot is already shared with this user');
+    }
+
+    return botShareRepository.create(botId, targetUser.id);
+  },
+
+  async unshareBot(botId: string, ownerUserId: string, targetUserId: string) {
+    const bot = await botRepository.findById(botId);
+    if (!bot) {
+      throw new NotFoundError('Bot not found');
+    }
+    if (bot.userId !== ownerUserId) {
+      throw new ForbiddenError('Only the bot owner can unshare this bot');
+    }
+
+    const existing = await botShareRepository.findByBotIdAndUserId(botId, targetUserId);
+    if (!existing) {
+      throw new NotFoundError('Share not found');
+    }
+
+    await botShareRepository.delete(botId, targetUserId);
+  },
+
+  async listShares(botId: string, requestingUserId: string) {
+    const bot = await botRepository.findById(botId);
+    if (!bot) {
+      throw new NotFoundError('Bot not found');
+    }
+
+    // Owner or shared user can view shares
+    if (bot.userId !== requestingUserId) {
+      const share = await botShareRepository.findByBotIdAndUserId(botId, requestingUserId);
+      if (!share) {
+        throw new ForbiddenError('You do not have access to this bot');
+      }
+    }
+
+    return botShareRepository.findByBotId(botId);
+  },
+};

--- a/web/src/hooks/useBot.ts
+++ b/web/src/hooks/useBot.ts
@@ -2,7 +2,13 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { apiClient } from '../lib/apiClient';
 import { queryKeys } from '../lib/queryKeys';
 
-type Bot = {
+type BotOwner = {
+  id: string;
+  email: string;
+  name: string;
+};
+
+export type Bot = {
   id: string;
   userId: string;
   xAccountHandle: string;
@@ -15,6 +21,7 @@ type Bot = {
   active: boolean;
   createdAt: string;
   updatedAt: string;
+  user?: BotOwner;
 };
 
 type BotListResponse = {
@@ -43,6 +50,24 @@ type UpdateBotInput = {
   preferredHoursStart?: number;
   preferredHoursEnd?: number;
   active?: boolean;
+};
+
+export type BotShareUser = {
+  id: string;
+  email: string;
+  name: string;
+};
+
+export type BotShare = {
+  id: string;
+  botId: string;
+  userId: string;
+  createdAt: string;
+  user: BotShareUser;
+};
+
+type BotShareListResponse = {
+  data: BotShare[];
 };
 
 export function useBot() {
@@ -107,6 +132,50 @@ export function useUpdateBot() {
     },
     onSettled: () => {
       void queryClient.invalidateQueries({ queryKey: queryKeys.bots.list });
+    },
+  });
+}
+
+export function useBotShares(botId: string | undefined) {
+  return useQuery({
+    queryKey: queryKeys.bots.shares(botId ?? ''),
+    queryFn: async () => {
+      const response = await apiClient.get<BotShareListResponse>(`/bots/${botId}/shares`);
+      return response.data.data;
+    },
+    enabled: !!botId,
+  });
+}
+
+export function useShareBot() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({ botId, email }: { botId: string; email: string }) => {
+      const response = await apiClient.post<{ data: BotShare }>(`/bots/${botId}/shares`, {
+        email,
+      });
+      return response.data.data;
+    },
+    onSuccess: (_data, variables) => {
+      void queryClient.invalidateQueries({
+        queryKey: queryKeys.bots.shares(variables.botId),
+      });
+    },
+  });
+}
+
+export function useUnshareBot() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({ botId, userId }: { botId: string; userId: string }) => {
+      await apiClient.delete(`/bots/${botId}/shares/${userId}`);
+    },
+    onSuccess: (_data, variables) => {
+      void queryClient.invalidateQueries({
+        queryKey: queryKeys.bots.shares(variables.botId),
+      });
     },
   });
 }

--- a/web/src/lib/queryKeys.ts
+++ b/web/src/lib/queryKeys.ts
@@ -5,6 +5,7 @@ export const queryKeys = {
   bots: {
     list: ['bots', 'list'] as const,
     detail: (id: string) => ['bots', 'detail', id] as const,
+    shares: (botId: string) => ['bots', 'shares', botId] as const,
   },
   posts: {
     list: (status?: string, page?: number) =>

--- a/web/src/pages/DashboardPage.tsx
+++ b/web/src/pages/DashboardPage.tsx
@@ -11,17 +11,32 @@ import DialogActions from '@mui/material/DialogActions';
 import DialogContent from '@mui/material/DialogContent';
 import DialogContentText from '@mui/material/DialogContentText';
 import DialogTitle from '@mui/material/DialogTitle';
+import Divider from '@mui/material/Divider';
 import Grid from '@mui/material/Grid';
+import IconButton from '@mui/material/IconButton';
+import List from '@mui/material/List';
+import ListItem from '@mui/material/ListItem';
+import ListItemText from '@mui/material/ListItemText';
 import MenuItem from '@mui/material/MenuItem';
 import Select from '@mui/material/Select';
 import Skeleton from '@mui/material/Skeleton';
 import Snackbar from '@mui/material/Snackbar';
 import Switch from '@mui/material/Switch';
+import TextField from '@mui/material/TextField';
 import Typography from '@mui/material/Typography';
 import CircularProgress from '@mui/material/CircularProgress';
+import DeleteIcon from '@mui/icons-material/Delete';
 import AppHeader from '../components/AppHeader';
 import BotSetupForm from '../components/BotSetupForm';
-import { useBot, useCreateBot, useUpdateBot } from '../hooks/useBot';
+import {
+  useBot,
+  useCreateBot,
+  useUpdateBot,
+  useBotShares,
+  useShareBot,
+  useUnshareBot,
+} from '../hooks/useBot';
+import { useAuth } from '../hooks/useAuth';
 import { useStats } from '../hooks/useStats';
 import { usePosts, type PostStatus } from '../hooks/usePosts';
 import { apiClient } from '../lib/apiClient';
@@ -54,12 +69,15 @@ type SnackbarState = {
 };
 
 export default function DashboardPage() {
+  const { user } = useAuth();
   const { bots, isLoading } = useBot();
   const createBot = useCreateBot();
   const updateBot = useUpdateBot();
   const [selectedBotIndex, setSelectedBotIndex] = useState(0);
   const [editOpen, setEditOpen] = useState(false);
   const [createOpen, setCreateOpen] = useState(false);
+  const [shareOpen, setShareOpen] = useState(false);
+  const [shareEmail, setShareEmail] = useState('');
   const [connectLoading, setConnectLoading] = useState(false);
   const [toggleConfirmOpen, setToggleConfirmOpen] = useState(false);
   const [snackbar, setSnackbar] = useState<SnackbarState>({
@@ -70,6 +88,11 @@ export default function DashboardPage() {
   const navigate = useNavigate();
 
   const bot = bots.length > 0 ? bots[Math.min(selectedBotIndex, bots.length - 1)] : null;
+  const isOwner = bot ? bot.userId === user?.id : false;
+
+  const { data: shares } = useBotShares(bot?.id);
+  const shareBot = useShareBot();
+  const unshareBot = useUnshareBot();
 
   const { data: stats, isLoading: statsLoading } = useStats(bot?.id);
   const { data: recentPostsData, isLoading: recentPostsLoading } = usePosts(undefined, 1, 5);
@@ -209,6 +232,11 @@ export default function DashboardPage() {
                   <MenuItem key={b.id} value={i}>
                     @{b.xAccountHandle || `Bot ${i + 1}`}
                     {!b.active && ' (paused)'}
+                    {b.userId !== user?.id && b.user
+                      ? ` (Owner: ${b.user.name})`
+                      : b.userId !== user?.id
+                        ? ' (Shared)'
+                        : ''}
                   </MenuItem>
                 ))}
               </Select>
@@ -231,12 +259,21 @@ export default function DashboardPage() {
             >
               <Box>
                 <Typography variant="h5">@{bot.xAccountHandle || 'Not connected'}</Typography>
-                <Chip
-                  label={bot.active ? 'Active' : 'Inactive'}
-                  color={bot.active ? 'success' : 'default'}
-                  size="small"
-                  sx={{ mt: 1 }}
-                />
+                <Box sx={{ display: 'flex', gap: 1, mt: 1 }}>
+                  <Chip
+                    label={bot.active ? 'Active' : 'Inactive'}
+                    color={bot.active ? 'success' : 'default'}
+                    size="small"
+                  />
+                  {!isOwner && (
+                    <Chip
+                      label={bot.user ? `Owner: ${bot.user.name}` : 'Shared'}
+                      color="info"
+                      size="small"
+                      variant="outlined"
+                    />
+                  )}
+                </Box>
               </Box>
               <Switch
                 checked={bot.active}
@@ -396,6 +433,134 @@ export default function DashboardPage() {
             Edit Bot Config
           </Button>
         </Box>
+
+        {/* Sharing Section (owner only) */}
+        {isOwner && (
+          <>
+            <Typography variant="h6" gutterBottom>
+              Sharing
+            </Typography>
+            <Card sx={{ mb: 3 }}>
+              <CardContent>
+                <Box
+                  sx={{
+                    display: 'flex',
+                    justifyContent: 'space-between',
+                    alignItems: 'center',
+                    mb: 1,
+                  }}
+                >
+                  <Typography variant="subtitle2">Shared with</Typography>
+                  <Button variant="outlined" size="small" onClick={() => setShareOpen(true)}>
+                    Share Bot
+                  </Button>
+                </Box>
+                {shares && shares.length > 0 ? (
+                  <List dense disablePadding>
+                    {shares.map((share, index) => (
+                      <div key={share.id}>
+                        {index > 0 && <Divider />}
+                        <ListItem
+                          secondaryAction={
+                            <IconButton
+                              edge="end"
+                              aria-label="unshare"
+                              onClick={() => {
+                                unshareBot.mutate(
+                                  { botId: bot.id, userId: share.userId },
+                                  {
+                                    onSuccess: () =>
+                                      showSnackbar(
+                                        `Removed ${share.user.email} from shared users`,
+                                        'success',
+                                      ),
+                                    onError: () =>
+                                      showSnackbar('Failed to remove shared user', 'error'),
+                                  },
+                                );
+                              }}
+                              disabled={unshareBot.isPending}
+                            >
+                              <DeleteIcon />
+                            </IconButton>
+                          }
+                        >
+                          <ListItemText
+                            primary={share.user.name}
+                            secondary={share.user.email}
+                          />
+                        </ListItem>
+                      </div>
+                    ))}
+                  </List>
+                ) : (
+                  <Typography variant="body2" color="text.secondary">
+                    This bot is not shared with anyone yet.
+                  </Typography>
+                )}
+              </CardContent>
+            </Card>
+          </>
+        )}
+
+        {/* Share Bot dialog */}
+        <Dialog
+          open={shareOpen}
+          onClose={() => {
+            setShareOpen(false);
+            setShareEmail('');
+          }}
+          maxWidth="xs"
+          fullWidth
+        >
+          <DialogTitle>Share Bot</DialogTitle>
+          <DialogContent>
+            <DialogContentText sx={{ mb: 2 }}>
+              Enter the email address of the user you want to share this bot with.
+            </DialogContentText>
+            <TextField
+              autoFocus
+              fullWidth
+              label="Email address"
+              type="email"
+              value={shareEmail}
+              onChange={(e) => setShareEmail(e.target.value)}
+            />
+          </DialogContent>
+          <DialogActions>
+            <Button
+              onClick={() => {
+                setShareOpen(false);
+                setShareEmail('');
+              }}
+              disabled={shareBot.isPending}
+            >
+              Cancel
+            </Button>
+            <Button
+              variant="contained"
+              disabled={!shareEmail || shareBot.isPending}
+              onClick={() => {
+                if (!bot) return;
+                shareBot.mutate(
+                  { botId: bot.id, email: shareEmail },
+                  {
+                    onSuccess: () => {
+                      setShareOpen(false);
+                      setShareEmail('');
+                      showSnackbar('Bot shared successfully', 'success');
+                    },
+                    onError: () => {
+                      showSnackbar('Failed to share bot', 'error');
+                    },
+                  },
+                );
+              }}
+            >
+              {shareBot.isPending ? 'Sharing...' : 'Share'}
+            </Button>
+          </DialogActions>
+        </Dialog>
 
         {/* Toggle confirmation dialog */}
         <Dialog open={toggleConfirmOpen} onClose={handleToggleCancel}>


### PR DESCRIPTION
## Summary
- Adds `BotShare` model (many-to-many join table) with unique constraint on botId+userId
- API endpoints: `POST /bots/:id/shares` (share by email), `DELETE /bots/:id/shares/:userId` (unshare), `GET /bots/:id/shares` (list)
- Only bot owner can share/unshare; shared users can view/edit bot settings
- `findByUserId` now returns both owned and shared bots
- Dashboard shows owner indicator on shared bots, sharing section for owners with share/unshare UI

## Test plan
- [ ] Owner shares bot by email — shared user sees bot in their dashboard
- [ ] Shared user can edit bot config but cannot share/unshare
- [ ] Owner unshares — bot disappears from shared user's dashboard
- [ ] Cannot share with yourself or duplicate share
- [ ] Bot switcher shows "(Owner: name)" for shared bots

🤖 Generated with [Claude Code](https://claude.com/claude-code)