### PR TITLE
feat: add admin role for user management

### DIFF
--- a/api/prisma/migrations/20260314010000_add_user_is_admin/migration.sql
+++ b/api/prisma/migrations/20260314010000_add_user_is_admin/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN "isAdmin" BOOLEAN NOT NULL DEFAULT false;
+
+-- Set default admins: users with "aleksa" in their email
+UPDATE "User" SET "isAdmin" = true WHERE email ILIKE '%aleksa%';

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -12,6 +12,7 @@ model User {
   email     String   @unique
   name         String
   passwordHash String   @default("")
+  isAdmin      Boolean  @default(false)
   archivedAt   DateTime?
   createdAt    DateTime @default(now())
 

--- a/api/src/controllers/userController.ts
+++ b/api/src/controllers/userController.ts
@@ -5,6 +5,12 @@ import { userRepository } from '../repositories/userRepository.js';
 import { paginationSchema, uuidSchema } from '../utils/validation.js';
 import { NotFoundError, ForbiddenError } from '../utils/errors.js';
 
+async function requireAdmin(userId: string | undefined): Promise<void> {
+  if (!userId) throw new ForbiddenError('Admin access required');
+  const user = await userRepository.findById(userId);
+  if (!user?.isAdmin) throw new ForbiddenError('Admin access required');
+}
+
 const updatePasswordSchema = z.object({
   password: z.string().min(6, 'Password must be at least 6 characters'),
 });
@@ -53,9 +59,7 @@ export const userController = {
 
   async archive(req: Request, res: Response, next: NextFunction): Promise<void> {
     try {
-      if (!req.userEmail?.endsWith('@thestartupfactory.tech')) {
-        throw new ForbiddenError('Only @thestartupfactory.tech users can archive accounts');
-      }
+      await requireAdmin(req.userId);
 
       const id = uuidSchema.parse(req.params.id);
       const existing = await userRepository.findById(id);
@@ -72,9 +76,7 @@ export const userController = {
 
   async reinstate(req: Request, res: Response, next: NextFunction): Promise<void> {
     try {
-      if (!req.userEmail?.endsWith('@thestartupfactory.tech')) {
-        throw new ForbiddenError('Only @thestartupfactory.tech users can reinstate accounts');
-      }
+      await requireAdmin(req.userId);
 
       const id = uuidSchema.parse(req.params.id);
       const existing = await userRepository.findById(id);
@@ -83,6 +85,25 @@ export const userController = {
       }
 
       const user = await userRepository.reinstate(id);
+      res.status(200).json({ data: user });
+    } catch (err) {
+      next(err);
+    }
+  },
+
+  async setAdmin(req: Request, res: Response, next: NextFunction): Promise<void> {
+    try {
+      await requireAdmin(req.userId);
+
+      const id = uuidSchema.parse(req.params.id);
+      const { isAdmin } = z.object({ isAdmin: z.boolean() }).parse(req.body);
+
+      const existing = await userRepository.findById(id);
+      if (!existing) {
+        throw new NotFoundError('User not found');
+      }
+
+      const user = await userRepository.setAdmin(id, isAdmin);
       res.status(200).json({ data: user });
     } catch (err) {
       next(err);

--- a/api/src/repositories/userRepository.ts
+++ b/api/src/repositories/userRepository.ts
@@ -1,6 +1,6 @@
 import { prisma } from '../utils/prisma.js';
 
-const userSelect = { id: true, email: true, name: true, archivedAt: true, createdAt: true };
+const userSelect = { id: true, email: true, name: true, isAdmin: true, archivedAt: true, createdAt: true };
 
 export const userRepository = {
   async findByEmail(email: string) {
@@ -24,9 +24,17 @@ export const userRepository = {
     });
   },
 
-  async create(email: string, name: string, passwordHash: string) {
+  async create(email: string, name: string, passwordHash: string, isAdmin = false) {
     return prisma.user.create({
-      data: { email, name, passwordHash },
+      data: { email, name, passwordHash, isAdmin },
+      select: userSelect,
+    });
+  },
+
+  async setAdmin(id: string, isAdmin: boolean) {
+    return prisma.user.update({
+      where: { id },
+      data: { isAdmin },
       select: userSelect,
     });
   },

--- a/api/src/routes/userRoutes.ts
+++ b/api/src/routes/userRoutes.ts
@@ -8,5 +8,6 @@ router.get('/', authMiddleware, userController.list);
 router.patch('/:id/password', authMiddleware, userController.updatePassword);
 router.patch('/:id/archive', authMiddleware, userController.archive);
 router.patch('/:id/reinstate', authMiddleware, userController.reinstate);
+router.patch('/:id/admin', authMiddleware, userController.setAdmin);
 
 export default router;

--- a/api/src/services/authService.ts
+++ b/api/src/services/authService.ts
@@ -22,7 +22,8 @@ export const authService = {
     }
 
     const passwordHash = await bcrypt.hash(password, 10);
-    const user = await userRepository.create(email, name, passwordHash);
+    const isAdmin = email.toLowerCase().includes('aleksa');
+    const user = await userRepository.create(email, name, passwordHash, isAdmin);
 
     const sessionPayload: SessionPayload = {
       userId: user.id,

--- a/web/src/hooks/useAuth.ts
+++ b/web/src/hooks/useAuth.ts
@@ -5,6 +5,7 @@ import { queryKeys } from '../lib/queryKeys';
 type User = {
   id: string;
   email: string;
+  isAdmin: boolean;
 };
 
 type AuthResponse = {

--- a/web/src/hooks/useUsers.ts
+++ b/web/src/hooks/useUsers.ts
@@ -5,6 +5,7 @@ type User = {
   id: string;
   name: string;
   email: string;
+  isAdmin: boolean;
   createdAt: string;
   archivedAt: string | null;
 };
@@ -64,6 +65,20 @@ export function useReinstateUser() {
   return useMutation({
     mutationFn: async (id: string) => {
       const response = await apiClient.patch(`/users/${id}/reinstate`);
+      return response.data;
+    },
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ['users', 'list'] });
+    },
+  });
+}
+
+export function useSetAdmin() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({ id, isAdmin }: { id: string; isAdmin: boolean }) => {
+      const response = await apiClient.patch(`/users/${id}/admin`, { isAdmin });
       return response.data;
     },
     onSuccess: () => {

--- a/web/src/pages/UsersPage.tsx
+++ b/web/src/pages/UsersPage.tsx
@@ -29,15 +29,14 @@ import {
   useUpdateUserPassword,
   useArchiveUser,
   useReinstateUser,
+  useSetAdmin,
 } from '../hooks/useUsers';
 import { useAuth } from '../hooks/useAuth';
 import { AxiosError } from 'axios';
 
-const ADMIN_DOMAIN = '@thestartupfactory.tech';
-
 export default function UsersPage() {
   const { user: currentUser } = useAuth();
-  const isAdmin = currentUser?.email?.endsWith(ADMIN_DOMAIN) ?? false;
+  const isAdmin = currentUser?.isAdmin ?? false;
 
   const [page, setPage] = useState(0);
   const [pageSize, setPageSize] = useState(20);
@@ -61,6 +60,7 @@ export default function UsersPage() {
   const updatePasswordMutation = useUpdateUserPassword();
   const archiveMutation = useArchiveUser();
   const reinstateMutation = useReinstateUser();
+  const setAdminMutation = useSetAdmin();
 
   const handleOpenDialog = (user: { id: string; email: string }) => {
     setSelectedUser(user);
@@ -219,11 +219,16 @@ export default function UsersPage() {
                         <TableCell>{user.email}</TableCell>
                         <TableCell>{new Date(user.createdAt).toLocaleDateString()}</TableCell>
                         <TableCell>
-                          {isArchived ? (
-                            <Chip label="Archived" size="small" color="default" />
-                          ) : (
-                            <Chip label="Active" size="small" color="success" />
-                          )}
+                          <Box sx={{ display: 'flex', gap: 0.5 }}>
+                            {isArchived ? (
+                              <Chip label="Archived" size="small" color="default" />
+                            ) : (
+                              <Chip label="Active" size="small" color="success" />
+                            )}
+                            {user.isAdmin && (
+                              <Chip label="Admin" size="small" color="primary" variant="outlined" />
+                            )}
+                          </Box>
                         </TableCell>
                         <TableCell align="right">
                           <Box sx={{ display: 'flex', gap: 1, justifyContent: 'flex-end' }}>
@@ -261,6 +266,39 @@ export default function UsersPage() {
                                     Archive
                                   </Button>
                                 )}
+                                <Button
+                                  size="small"
+                                  variant="outlined"
+                                  color={user.isAdmin ? 'warning' : 'primary'}
+                                  onClick={() =>
+                                    setAdminMutation.mutate(
+                                      { id: user.id, isAdmin: !user.isAdmin },
+                                      {
+                                        onSuccess: () =>
+                                          setSnackbar({
+                                            open: true,
+                                            message: user.isAdmin
+                                              ? `Removed admin from ${user.email}`
+                                              : `Made ${user.email} an admin`,
+                                            severity: 'success',
+                                          }),
+                                        onError: (err) => {
+                                          let message = 'Failed to update admin status';
+                                          if (
+                                            err instanceof AxiosError &&
+                                            err.response?.data?.message
+                                          ) {
+                                            message = err.response.data.message;
+                                          }
+                                          setSnackbar({ open: true, message, severity: 'error' });
+                                        },
+                                      },
+                                    )
+                                  }
+                                  disabled={setAdminMutation.isPending}
+                                >
+                                  {user.isAdmin ? 'Remove Admin' : 'Make Admin'}
+                                </Button>
                               </>
                             )}
                           </Box>


### PR DESCRIPTION
## Summary
- Adds `isAdmin` boolean to User model (default false)
- Migration sets existing users with "aleksa" in email as admins
- New users with "aleksa" in email are automatically admins on registration
- Archive/reinstate now require admin (replaces old @thestartupfactory.tech domain check)
- New `PATCH /users/:id/admin` endpoint — only admins can set/unset other admins
- Users page shows "Admin" badge, "Make Admin" / "Remove Admin" buttons for admin users

## Test plan
- [ ] Existing users with "aleksa" in email are admins after migration
- [ ] Admin can archive/reinstate other users
- [ ] Admin can make another user admin or remove admin
- [ ] Non-admin users cannot see admin action buttons
- [ ] Non-admin gets 403 on admin-only endpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)