### PR TITLE
feat: scope posts and jobs to user's bots, add admin show-all toggle

### DIFF
--- a/api/src/controllers/jobQueueController.ts
+++ b/api/src/controllers/jobQueueController.ts
@@ -1,13 +1,37 @@
 import { Request, Response, NextFunction } from 'express';
 import { prisma } from '../utils/prisma.js';
 import { jobRepository } from '../repositories/jobRepository.js';
+import { userRepository } from '../repositories/userRepository.js';
 import { getEntries as getActivityLog } from '../worker/activityLog.js';
 import { log } from '../worker/activityLog.js';
 
 export const jobQueueController = {
   async cancelJob(req: Request<{ id: string }>, res: Response, next: NextFunction): Promise<void> {
     try {
+      const userId = req.userId!;
       const { id } = req.params;
+
+      // Verify the job belongs to a bot the user owns/shares, or user is admin
+      const job = await prisma.job.findUnique({
+        where: { id },
+        include: { bot: { include: { shares: true } } },
+      });
+
+      if (!job) {
+        res.status(404).json({ error: 'Job not found or not cancellable' });
+        return;
+      }
+
+      const user = await userRepository.findById(userId);
+      const isOwnerOrShared =
+        job.bot.userId === userId ||
+        job.bot.shares.some((s) => s.userId === userId);
+
+      if (!isOwnerOrShared && !user?.isAdmin) {
+        res.status(403).json({ error: 'You do not have access to this job' });
+        return;
+      }
+
       const result = await jobRepository.cancel(id);
 
       if (result.count === 0) {
@@ -24,6 +48,25 @@ export const jobQueueController = {
 
   async getStats(req: Request, res: Response, next: NextFunction): Promise<void> {
     try {
+      const userId = req.userId!;
+
+      // Determine if we should scope to user's bots
+      let botFilter: Record<string, unknown> | undefined;
+      const showAll = req.query.showAll === 'true';
+      if (showAll) {
+        const user = await userRepository.findById(userId);
+        if (!user?.isAdmin) {
+          // Non-admin: ignore showAll, scope to their bots
+          botFilter = { bot: { OR: [{ userId }, { shares: { some: { userId } } }] } };
+        }
+        // Admin with showAll: no filter
+      } else {
+        botFilter = { bot: { OR: [{ userId }, { shares: { some: { userId } } }] } };
+      }
+
+      const jobWhere = botFilter ?? {};
+      const postWhere = botFilter ?? {};
+
       const [
         jobCountsByStatus,
         postCountsByStatus,
@@ -36,36 +79,38 @@ export const jobQueueController = {
         prisma.job.groupBy({
           by: ['status'],
           _count: { status: true },
+          ...(botFilter ? { where: jobWhere } : {}),
         }),
         prisma.post.groupBy({
           by: ['status'],
           _count: { status: true },
+          ...(botFilter ? { where: postWhere } : {}),
         }),
         prisma.job.findMany({
-          where: { completedAt: { not: null } },
+          where: { completedAt: { not: null }, ...jobWhere },
           orderBy: { completedAt: 'desc' },
           take: 10,
           include: { bot: { select: { xAccountHandle: true } } },
         }),
         prisma.job.findMany({
-          where: { status: 'pending' },
+          where: { status: 'pending', ...jobWhere },
           orderBy: { scheduledAt: 'asc' },
           take: 10,
           include: { bot: { select: { xAccountHandle: true } } },
         }),
         prisma.job.findMany({
-          where: { status: 'failed' },
+          where: { status: 'failed', ...jobWhere },
           orderBy: { completedAt: 'desc' },
           take: 10,
           include: { bot: { select: { xAccountHandle: true } } },
         }),
         prisma.job.findFirst({
-          where: { completedAt: { not: null } },
+          where: { completedAt: { not: null }, ...jobWhere },
           orderBy: { completedAt: 'desc' },
           select: { completedAt: true },
         }),
         prisma.job.findFirst({
-          where: { status: 'pending' },
+          where: { status: 'pending', ...jobWhere },
           orderBy: { scheduledAt: 'asc' },
           select: { scheduledAt: true },
         }),

--- a/api/src/controllers/postController.ts
+++ b/api/src/controllers/postController.ts
@@ -1,10 +1,12 @@
 import { Request, Response, NextFunction } from 'express';
 import { z } from 'zod';
 import { postService } from '../services/postService.js';
+import { userRepository } from '../repositories/userRepository.js';
 import { paginationSchema, uuidSchema } from '../utils/validation.js';
 
 const postListQuerySchema = paginationSchema.extend({
   status: z.string().optional(),
+  showAll: z.string().optional(),
 });
 
 const postIdParamSchema = z.object({
@@ -22,12 +24,20 @@ export const postController = {
   async list(req: Request, res: Response, next: NextFunction): Promise<void> {
     try {
       const userId = req.userId!;
-      const { page, pageSize, status } = postListQuerySchema.parse(req.query);
-      const { posts, total } = await postService.listPosts(userId, {
-        status,
-        page,
-        pageSize,
-      });
+      const { page, pageSize, status, showAll } = postListQuerySchema.parse(req.query);
+
+      let scopeToUser = true;
+      if (showAll === 'true') {
+        const user = await userRepository.findById(userId);
+        if (user?.isAdmin) {
+          scopeToUser = false;
+        }
+      }
+
+      const { posts, total } = await postService.listPosts(
+        scopeToUser ? userId : undefined,
+        { status, page, pageSize },
+      );
 
       res.status(200).json({
         data: posts,

--- a/api/src/repositories/postRepository.ts
+++ b/api/src/repositories/postRepository.ts
@@ -26,6 +26,25 @@ export const postRepository = {
     });
   },
 
+  async findAll(options: { status?: string; page: number; pageSize: number }) {
+    const where: { status?: string } = {};
+    if (options.status) {
+      where.status = options.status;
+    }
+
+    const [posts, total] = await Promise.all([
+      prisma.post.findMany({
+        where,
+        skip: (options.page - 1) * options.pageSize,
+        take: options.pageSize,
+        orderBy: { createdAt: 'desc' },
+      }),
+      prisma.post.count({ where }),
+    ]);
+
+    return { posts, total };
+  },
+
   async findByBotIds(
     botIds: string[],
     options: { status?: string; page: number; pageSize: number },

--- a/api/src/services/postService.ts
+++ b/api/src/services/postService.ts
@@ -10,7 +10,12 @@ type UpdatePostInput = {
 };
 
 export const postService = {
-  async listPosts(userId: string, options: { status?: string; page: number; pageSize: number }) {
+  async listPosts(userId: string | undefined, options: { status?: string; page: number; pageSize: number }) {
+    if (!userId) {
+      // Admin show-all: no bot scoping
+      return postRepository.findAll(options);
+    }
+
     const { bots } = await botRepository.findByUserId(userId, 1, 1000);
     const botIds = bots.map((b: { id: string }) => b.id);
 

--- a/web/src/hooks/useJobQueue.ts
+++ b/web/src/hooks/useJobQueue.ts
@@ -48,11 +48,15 @@ type JobQueueStatsResponse = {
   data: JobQueueStats;
 };
 
-export function useJobQueue() {
+export function useJobQueue(showAll = false) {
   return useQuery({
-    queryKey: queryKeys.jobs.stats,
+    queryKey: queryKeys.jobs.stats(showAll),
     queryFn: async () => {
-      const response = await apiClient.get<JobQueueStatsResponse>('/jobs/stats');
+      const params: Record<string, string> = {};
+      if (showAll) {
+        params.showAll = 'true';
+      }
+      const response = await apiClient.get<JobQueueStatsResponse>('/jobs/stats', { params });
       return response.data.data;
     },
     refetchInterval: 30000,
@@ -66,7 +70,7 @@ export function useCancelJob() {
       await apiClient.post(`/jobs/${jobId}/cancel`);
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: queryKeys.jobs.stats });
+      queryClient.invalidateQueries({ queryKey: ['jobs', 'stats'] });
     },
   });
 }

--- a/web/src/hooks/usePosts.ts
+++ b/web/src/hooks/usePosts.ts
@@ -32,13 +32,16 @@ type UpdatePostInput = {
   rating?: number | null;
 };
 
-export function usePosts(status?: string, page = 1, pageSize = 10) {
+export function usePosts(status?: string, page = 1, pageSize = 10, showAll = false) {
   return useQuery({
-    queryKey: queryKeys.posts.list(status, page),
+    queryKey: queryKeys.posts.list(status, page, showAll),
     queryFn: async () => {
-      const params: Record<string, string | number> = { page, pageSize };
+      const params: Record<string, string | number | boolean> = { page, pageSize };
       if (status) {
         params.status = status;
+      }
+      if (showAll) {
+        params.showAll = 'true';
       }
       const response = await apiClient.get<PostListResponse>('/posts', {
         params,

--- a/web/src/lib/queryKeys.ts
+++ b/web/src/lib/queryKeys.ts
@@ -8,14 +8,14 @@ export const queryKeys = {
     shares: (botId: string) => ['bots', 'shares', botId] as const,
   },
   posts: {
-    list: (status?: string, page?: number) =>
-      ['posts', 'list', status ?? 'all', page ?? 1] as const,
+    list: (status?: string, page?: number, showAll?: boolean) =>
+      ['posts', 'list', status ?? 'all', page ?? 1, showAll ?? false] as const,
     all: ['posts'] as const,
   },
   stats: {
     forBot: (botId: string) => ['stats', 'bot', botId] as const,
   },
   jobs: {
-    stats: ['jobs', 'stats'] as const,
+    stats: (showAll?: boolean) => ['jobs', 'stats', showAll ?? false] as const,
   },
 } as const;

--- a/web/src/pages/JobQueuePage.tsx
+++ b/web/src/pages/JobQueuePage.tsx
@@ -21,8 +21,11 @@ import TableRow from '@mui/material/TableRow';
 import Typography from '@mui/material/Typography';
 import CloseIcon from '@mui/icons-material/Close';
 import Button from '@mui/material/Button';
+import FormControlLabel from '@mui/material/FormControlLabel';
+import Switch from '@mui/material/Switch';
 import CancelIcon from '@mui/icons-material/Cancel';
 import AppHeader from '../components/AppHeader';
+import { useAuth } from '../hooks/useAuth';
 import { useJobQueue, useCancelJob } from '../hooks/useJobQueue';
 
 function formatRelativeTime(dateStr: string | null): string {
@@ -222,7 +225,9 @@ function JobDetailDialog({
 }
 
 export default function JobQueuePage() {
-  const { data, isLoading, error } = useJobQueue();
+  const { user } = useAuth();
+  const [showAll, setShowAll] = useState(false);
+  const { data, isLoading, error } = useJobQueue(showAll);
   const cancelJob = useCancelJob();
   const [selectedJob, setSelectedJob] = useState<JobDetail | null>(null);
 
@@ -256,10 +261,23 @@ export default function JobQueuePage() {
       <Container maxWidth="lg" sx={{ mt: 4 }}>
         {/* Header */}
         <Box sx={{ mb: 3 }}>
-          <Typography variant="h4" gutterBottom>
-            Job Queue
-          </Typography>
-          <Typography variant="body2" color="text.secondary">
+          <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+            <Typography variant="h4" gutterBottom sx={{ mb: 0 }}>
+              Job Queue
+            </Typography>
+            {user?.isAdmin && (
+              <FormControlLabel
+                control={
+                  <Switch
+                    checked={showAll}
+                    onChange={(e) => setShowAll(e.target.checked)}
+                  />
+                }
+                label="Show all bots"
+              />
+            )}
+          </Box>
+          <Typography variant="body2" color="text.secondary" sx={{ mt: 1 }}>
             Last completed: {formatRelativeTime(data.lastCompletedAt)} | Next scheduled:{' '}
             {formatRelativeTime(data.nextScheduledAt)}
           </Typography>

--- a/web/src/pages/PostsPage.tsx
+++ b/web/src/pages/PostsPage.tsx
@@ -1,5 +1,7 @@
 import { useState } from 'react';
 import Container from '@mui/material/Container';
+import FormControlLabel from '@mui/material/FormControlLabel';
+import Switch from '@mui/material/Switch';
 import Typography from '@mui/material/Typography';
 import Tabs from '@mui/material/Tabs';
 import Tab from '@mui/material/Tab';
@@ -8,6 +10,7 @@ import Button from '@mui/material/Button';
 import Skeleton from '@mui/material/Skeleton';
 import AppHeader from '../components/AppHeader';
 import PostCard from '../components/PostCard';
+import { useAuth } from '../hooks/useAuth';
 import { usePosts } from '../hooks/usePosts';
 
 const TAB_CONFIG = [
@@ -31,11 +34,13 @@ const TAB_CONFIG = [
 ] as const;
 
 export default function PostsPage() {
+  const { user } = useAuth();
   const [tabIndex, setTabIndex] = useState(0);
   const [page, setPage] = useState(1);
+  const [showAll, setShowAll] = useState(false);
 
   const currentTab = TAB_CONFIG[tabIndex];
-  const { data, isLoading } = usePosts(currentTab.status, page);
+  const { data, isLoading } = usePosts(currentTab.status, page, 10, showAll);
 
   const posts = data?.data ?? [];
   const meta = data?.meta;
@@ -54,9 +59,25 @@ export default function PostsPage() {
     <>
       <AppHeader />
       <Container maxWidth="md" sx={{ mt: 4 }}>
-        <Typography variant="h4" gutterBottom>
-          Posts
-        </Typography>
+        <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 1 }}>
+          <Typography variant="h4" gutterBottom sx={{ mb: 0 }}>
+            Posts
+          </Typography>
+          {user?.isAdmin && (
+            <FormControlLabel
+              control={
+                <Switch
+                  checked={showAll}
+                  onChange={(e) => {
+                    setShowAll(e.target.checked);
+                    setPage(1);
+                  }}
+                />
+              }
+              label="Show all bots"
+            />
+          )}
+        </Box>
 
         <Box sx={{ borderBottom: 1, borderColor: 'divider', mb: 3 }}>
           <Tabs


### PR DESCRIPTION
## Summary
- **Posts endpoint**: Scoped to user's owned + shared bots by default. Admin with `showAll=true` sees all.
- **Job queue stats**: All 7 queries (counts, recent, upcoming, errors, timestamps) filtered to user's bots. Admin toggle removes filter.
- **Job cancel**: Now verifies the job belongs to user's bot (owned/shared) or user is admin before allowing cancel.
- **Frontend**: Both Posts and Job Queue pages show a "Show all bots" toggle for admin users.
- Query keys updated to include `showAll` for proper cache separation.

## Test plan
- [ ] Non-admin user sees only posts/jobs for their owned and shared bots
- [ ] Admin user with toggle off sees only their own data
- [ ] Admin user with toggle on sees all data across all bots
- [ ] Non-admin cannot use showAll param (silently ignored)
- [ ] Cancel job still works and respects authorization

🤖 Generated with [Claude Code](https://claude.com/claude-code)