### PR TITLE
feat: add AI post tweaking with feedback and bot memory tips

### DIFF
--- a/api/prisma/migrations/20260314020000_add_bot_tip/migration.sql
+++ b/api/prisma/migrations/20260314020000_add_bot_tip/migration.sql
@@ -1,0 +1,12 @@
+-- CreateTable
+CREATE TABLE "BotTip" (
+    "id" UUID NOT NULL DEFAULT gen_random_uuid(),
+    "botId" UUID NOT NULL,
+    "content" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "BotTip_pkey" PRIMARY KEY ("id")
+);
+
+-- AddForeignKey
+ALTER TABLE "BotTip" ADD CONSTRAINT "BotTip_botId_fkey" FOREIGN KEY ("botId") REFERENCES "Bot"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -39,6 +39,7 @@ model Bot {
   posts  Post[]
   jobs   Job[]
   shares BotShare[]
+  tips   BotTip[]
 }
 
 model BotShare {
@@ -69,6 +70,15 @@ model Post {
 
   @@index([botId, status])
   @@index([status, scheduledAt])
+}
+
+model BotTip {
+  id        String   @id @default(uuid()) @db.Uuid
+  botId     String   @db.Uuid
+  content   String   @db.Text
+  createdAt DateTime @default(now())
+
+  bot Bot @relation(fields: [botId], references: [id])
 }
 
 model Job {

--- a/api/src/controllers/botTipController.ts
+++ b/api/src/controllers/botTipController.ts
@@ -1,0 +1,92 @@
+import { Request, Response, NextFunction } from 'express';
+import { z } from 'zod';
+import { botTipRepository } from '../repositories/botTipRepository.js';
+import { botRepository } from '../repositories/botRepository.js';
+import { botShareRepository } from '../repositories/botShareRepository.js';
+import { uuidSchema } from '../utils/validation.js';
+import { NotFoundError, ForbiddenError } from '../utils/errors.js';
+
+const botIdParamSchema = z.object({
+  id: uuidSchema,
+});
+
+const tipIdParamSchema = z.object({
+  id: uuidSchema,
+  tipId: uuidSchema,
+});
+
+const updateTipSchema = z.object({
+  content: z.string().min(1, 'Content must not be empty'),
+});
+
+async function assertBotAccess(botId: string, userId: string): Promise<void> {
+  const bot = await botRepository.findById(botId);
+  if (!bot) {
+    throw new NotFoundError('Bot not found');
+  }
+  if (bot.userId !== userId) {
+    const share = await botShareRepository.findByBotIdAndUserId(botId, userId);
+    if (!share) {
+      throw new ForbiddenError('You do not have access to this bot');
+    }
+  }
+}
+
+export const botTipController = {
+  async list(req: Request, res: Response, next: NextFunction): Promise<void> {
+    try {
+      const userId = req.userId!;
+      const { id } = botIdParamSchema.parse(req.params);
+      await assertBotAccess(id, userId);
+
+      const tips = await botTipRepository.findByBotId(id);
+
+      res.status(200).json({
+        data: tips,
+      });
+    } catch (err) {
+      next(err);
+    }
+  },
+
+  async update(req: Request, res: Response, next: NextFunction): Promise<void> {
+    try {
+      const userId = req.userId!;
+      const { id, tipId } = tipIdParamSchema.parse(req.params);
+      await assertBotAccess(id, userId);
+
+      const tip = await botTipRepository.findById(tipId);
+      if (!tip || tip.botId !== id) {
+        throw new NotFoundError('Tip not found');
+      }
+
+      const { content } = updateTipSchema.parse(req.body);
+      const updated = await botTipRepository.update(tipId, content);
+
+      res.status(200).json({
+        data: updated,
+      });
+    } catch (err) {
+      next(err);
+    }
+  },
+
+  async remove(req: Request, res: Response, next: NextFunction): Promise<void> {
+    try {
+      const userId = req.userId!;
+      const { id, tipId } = tipIdParamSchema.parse(req.params);
+      await assertBotAccess(id, userId);
+
+      const tip = await botTipRepository.findById(tipId);
+      if (!tip || tip.botId !== id) {
+        throw new NotFoundError('Tip not found');
+      }
+
+      await botTipRepository.delete(tipId);
+
+      res.status(204).send();
+    } catch (err) {
+      next(err);
+    }
+  },
+};

--- a/api/src/controllers/postController.ts
+++ b/api/src/controllers/postController.ts
@@ -20,6 +20,28 @@ const updatePostSchema = z.object({
   scheduledAt: z.string().datetime().nullable().optional(),
 });
 
+const tweakPostSchema = z.object({
+  feedback: z.string().min(1, 'Feedback is required'),
+  previousMessages: z
+    .array(
+      z.object({
+        role: z.enum(['user', 'assistant']),
+        content: z.string(),
+      }),
+    )
+    .optional(),
+});
+
+const acceptTweakSchema = z.object({
+  content: z.string().min(1, 'Content is required'),
+  conversation: z.array(
+    z.object({
+      role: z.string(),
+      content: z.string(),
+    }),
+  ),
+});
+
 export const postController = {
   async list(req: Request, res: Response, next: NextFunction): Promise<void> {
     try {
@@ -57,6 +79,36 @@ export const postController = {
 
       res.status(200).json({
         data: post,
+      });
+    } catch (err) {
+      next(err);
+    }
+  },
+
+  async tweak(req: Request, res: Response, next: NextFunction): Promise<void> {
+    try {
+      const userId = req.userId!;
+      const { id } = postIdParamSchema.parse(req.params);
+      const { feedback, previousMessages } = tweakPostSchema.parse(req.body);
+      const result = await postService.tweakPost(id, userId, feedback, previousMessages);
+
+      res.status(200).json({
+        data: result,
+      });
+    } catch (err) {
+      next(err);
+    }
+  },
+
+  async acceptTweak(req: Request, res: Response, next: NextFunction): Promise<void> {
+    try {
+      const userId = req.userId!;
+      const { id } = postIdParamSchema.parse(req.params);
+      const { content, conversation } = acceptTweakSchema.parse(req.body);
+      const result = await postService.acceptTweak(id, userId, content, conversation);
+
+      res.status(200).json({
+        data: result,
       });
     } catch (err) {
       next(err);

--- a/api/src/repositories/botTipRepository.ts
+++ b/api/src/repositories/botTipRepository.ts
@@ -1,0 +1,52 @@
+import { prisma } from '../utils/prisma.js';
+
+export const botTipRepository = {
+  async create(data: { botId: string; content: string }) {
+    return prisma.botTip.create({
+      data: {
+        botId: data.botId,
+        content: data.content,
+      },
+    });
+  },
+
+  async createMany(tips: Array<{ botId: string; content: string }>) {
+    const created = await Promise.all(
+      tips.map((tip) =>
+        prisma.botTip.create({
+          data: {
+            botId: tip.botId,
+            content: tip.content,
+          },
+        }),
+      ),
+    );
+    return created;
+  },
+
+  async findByBotId(botId: string) {
+    return prisma.botTip.findMany({
+      where: { botId },
+      orderBy: { createdAt: 'desc' },
+    });
+  },
+
+  async findById(id: string) {
+    return prisma.botTip.findUnique({
+      where: { id },
+    });
+  },
+
+  async update(id: string, content: string) {
+    return prisma.botTip.update({
+      where: { id },
+      data: { content },
+    });
+  },
+
+  async delete(id: string) {
+    return prisma.botTip.delete({
+      where: { id },
+    });
+  },
+};

--- a/api/src/routes/botRoutes.ts
+++ b/api/src/routes/botRoutes.ts
@@ -1,6 +1,7 @@
 import { Router } from 'express';
 import { botController } from '../controllers/botController.js';
 import { botShareController } from '../controllers/botShareController.js';
+import { botTipController } from '../controllers/botTipController.js';
 import { authMiddleware } from '../middleware/auth.js';
 
 const router = Router();
@@ -17,5 +18,10 @@ router.patch('/:id', botController.update);
 router.post('/:id/shares', botShareController.create);
 router.get('/:id/shares', botShareController.list);
 router.delete('/:id/shares/:userId', botShareController.remove);
+
+// Tip routes
+router.get('/:id/tips', botTipController.list);
+router.patch('/:id/tips/:tipId', botTipController.update);
+router.delete('/:id/tips/:tipId', botTipController.remove);
 
 export default router;

--- a/api/src/routes/postRoutes.ts
+++ b/api/src/routes/postRoutes.ts
@@ -9,5 +9,7 @@ router.use(authMiddleware);
 
 router.get('/', postController.list);
 router.patch('/:id', postController.update);
+router.post('/:id/tweak', postController.tweak);
+router.post('/:id/accept-tweak', postController.acceptTweak);
 
 export default router;

--- a/api/src/services/aiService.ts
+++ b/api/src/services/aiService.ts
@@ -15,11 +15,21 @@ Rules:
 - Do not include quotation marks around the tweet
 - Output ONLY the tweet text, nothing else`;
 
-async function callClaude(client: Anthropic, prompt: string): Promise<string> {
+const TWEAK_SYSTEM_PROMPT = `You are helping revise a tweet. Given the current tweet and user feedback, output ONLY the revised tweet text (under 280 chars). Do not include quotation marks around the tweet.`;
+
+const TIPS_SYSTEM_PROMPT = `Analyze this conversation where a user refined a tweet draft. Extract 1-3 concise tips/preferences that should guide future tweet generation for this account. Each tip should be a single sentence. Output only the tips, one per line.`;
+
+function getClient(): Anthropic | null {
+  const apiKey = process.env.ANTHROPIC_API_KEY;
+  if (!apiKey) return null;
+  return new Anthropic({ apiKey });
+}
+
+async function callClaude(client: Anthropic, prompt: string, systemPrompt?: string): Promise<string> {
   const response = await client.messages.create({
     model: 'claude-sonnet-4-20250514',
     max_tokens: 300,
-    system: SYSTEM_PROMPT,
+    system: systemPrompt ?? SYSTEM_PROMPT,
     messages: [{ role: 'user', content: prompt }],
   });
 
@@ -31,10 +41,30 @@ async function callClaude(client: Anthropic, prompt: string): Promise<string> {
   throw new Error('Unexpected response format from Claude API');
 }
 
-export async function generateTweet(prompt: string): Promise<GenerateTweetResult> {
-  const apiKey = process.env.ANTHROPIC_API_KEY;
+async function callClaudeWithMessages(
+  client: Anthropic,
+  systemPrompt: string,
+  messages: Array<{ role: 'user' | 'assistant'; content: string }>,
+): Promise<string> {
+  const response = await client.messages.create({
+    model: 'claude-sonnet-4-20250514',
+    max_tokens: 300,
+    system: systemPrompt,
+    messages,
+  });
 
-  if (!apiKey) {
+  const block = response.content[0];
+  if (block.type === 'text') {
+    return block.text.trim();
+  }
+
+  throw new Error('Unexpected response format from Claude API');
+}
+
+export async function generateTweet(prompt: string, tips?: string[]): Promise<GenerateTweetResult> {
+  const client = getClient();
+
+  if (!client) {
     return {
       content: 'AI service not configured \u2014 set ANTHROPIC_API_KEY',
       success: false,
@@ -42,20 +72,73 @@ export async function generateTweet(prompt: string): Promise<GenerateTweetResult
     };
   }
 
-  const client = new Anthropic({ apiKey });
+  let systemPrompt = SYSTEM_PROMPT;
+  if (tips && tips.length > 0) {
+    systemPrompt += `\n\nRemember these tips from past feedback:\n${tips.map((t) => `- ${t}`).join('\n')}`;
+  }
 
   // First attempt
   try {
-    const content = await callClaude(client, prompt);
+    const content = await callClaude(client, prompt, systemPrompt);
     return { content, success: true };
   } catch {
     // Retry once on failure
     try {
-      const content = await callClaude(client, prompt);
+      const content = await callClaude(client, prompt, systemPrompt);
       return { content, success: true };
     } catch (retryErr: unknown) {
       const message = retryErr instanceof Error ? retryErr.message : String(retryErr);
       return { content: '', success: false, error: message };
     }
   }
+}
+
+export async function tweakPost(
+  currentContent: string,
+  feedback: string,
+  previousMessages?: Array<{ role: 'user' | 'assistant'; content: string }>,
+): Promise<string> {
+  const client = getClient();
+  if (!client) {
+    throw new Error('AI service not configured \u2014 set ANTHROPIC_API_KEY');
+  }
+
+  const messages: Array<{ role: 'user' | 'assistant'; content: string }> = [];
+
+  if (previousMessages && previousMessages.length > 0) {
+    messages.push(...previousMessages);
+  } else {
+    messages.push({ role: 'user', content: `Current tweet:\n${currentContent}` });
+  }
+
+  messages.push({ role: 'user', content: `Feedback: ${feedback}` });
+
+  const revised = await callClaudeWithMessages(client, TWEAK_SYSTEM_PROMPT, messages);
+  return revised;
+}
+
+export async function generateTips(
+  conversation: Array<{ role: string; content: string }>,
+): Promise<string[]> {
+  const client = getClient();
+  if (!client) {
+    throw new Error('AI service not configured \u2014 set ANTHROPIC_API_KEY');
+  }
+
+  const formattedConversation = conversation
+    .map((msg) => `${msg.role}: ${msg.content}`)
+    .join('\n\n');
+
+  const result = await callClaude(
+    client,
+    `Here is the conversation:\n\n${formattedConversation}`,
+    TIPS_SYSTEM_PROMPT,
+  );
+
+  const tips = result
+    .split('\n')
+    .map((line) => line.replace(/^[-*•]\s*/, '').trim())
+    .filter((line) => line.length > 0);
+
+  return tips;
 }

--- a/api/src/services/postService.ts
+++ b/api/src/services/postService.ts
@@ -1,5 +1,7 @@
 import { botRepository } from '../repositories/botRepository.js';
 import { postRepository } from '../repositories/postRepository.js';
+import { botTipRepository } from '../repositories/botTipRepository.js';
+import { tweakPost, generateTips } from './aiService.js';
 import { NotFoundError, ForbiddenError, ValidationError } from '../utils/errors.js';
 
 type UpdatePostInput = {
@@ -87,6 +89,65 @@ export const postService = {
     }
 
     return postRepository.update(postId, updateData);
+  },
+
+  async tweakPost(
+    postId: string,
+    userId: string,
+    feedback: string,
+    previousMessages?: Array<{ role: 'user' | 'assistant'; content: string }>,
+  ) {
+    const post = await postRepository.findById(postId);
+    if (!post) {
+      throw new NotFoundError('Post not found');
+    }
+    if (post.bot.userId !== userId) {
+      throw new ForbiddenError('You do not have access to this post');
+    }
+    if (post.status !== 'draft') {
+      throw new ValidationError('Only draft posts can be tweaked');
+    }
+
+    const revised = await tweakPost(post.content, feedback, previousMessages);
+    return { content: revised };
+  },
+
+  async acceptTweak(
+    postId: string,
+    userId: string,
+    content: string,
+    conversation: Array<{ role: string; content: string }>,
+  ) {
+    const post = await postRepository.findById(postId);
+    if (!post) {
+      throw new NotFoundError('Post not found');
+    }
+    if (post.bot.userId !== userId) {
+      throw new ForbiddenError('You do not have access to this post');
+    }
+    if (post.status !== 'draft') {
+      throw new ValidationError('Only draft posts can be updated');
+    }
+
+    const updatedPost = await postRepository.update(postId, { content });
+
+    // Generate tips from the conversation
+    let newTips: Array<{ id: string; botId: string; content: string; createdAt: Date }> = [];
+    try {
+      const tipStrings = await generateTips(conversation);
+      if (tipStrings.length > 0) {
+        newTips = await botTipRepository.createMany(
+          tipStrings.map((tipContent) => ({
+            botId: post.botId,
+            content: tipContent,
+          })),
+        );
+      }
+    } catch {
+      // Tips generation is best-effort; don't fail the accept
+    }
+
+    return { post: updatedPost, newTips };
   },
 };
 

--- a/api/src/worker/jobWorker.ts
+++ b/api/src/worker/jobWorker.ts
@@ -1,6 +1,7 @@
 import { v4 as uuidv4 } from 'uuid';
 import { jobRepository } from '../repositories/jobRepository.js';
 import { postRepository } from '../repositories/postRepository.js';
+import { botTipRepository } from '../repositories/botTipRepository.js';
 import { generateTweet } from '../services/aiService.js';
 import { computeNextScheduledAt } from '../services/scheduler.js';
 import { log } from './activityLog.js';
@@ -137,7 +138,8 @@ async function processJobs(): Promise<void> {
           continue;
         }
 
-        const result = await generateTweet(bot.prompt);
+        const tips = await botTipRepository.findByBotId(bot.id);
+        const result = await generateTweet(bot.prompt, tips.map((t) => t.content));
 
         if (!result.success) {
           const errorMsg = `AI generation failed: ${result.error}`;

--- a/web/src/components/PostCard.tsx
+++ b/web/src/components/PostCard.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useRef, useEffect } from 'react';
 import Box from '@mui/material/Box';
 import Card from '@mui/material/Card';
 import CardContent from '@mui/material/CardContent';
@@ -7,8 +7,14 @@ import Typography from '@mui/material/Typography';
 import TextField from '@mui/material/TextField';
 import Button from '@mui/material/Button';
 import Rating from '@mui/material/Rating';
+import Dialog from '@mui/material/Dialog';
+import DialogTitle from '@mui/material/DialogTitle';
+import DialogContent from '@mui/material/DialogContent';
+import DialogActions from '@mui/material/DialogActions';
+import Alert from '@mui/material/Alert';
+import CircularProgress from '@mui/material/CircularProgress';
 import type { Post, PostStatus } from '../hooks/usePosts';
-import { useUpdatePost } from '../hooks/usePosts';
+import { useUpdatePost, useTweakPost, useAcceptTweak } from '../hooks/usePosts';
 
 const statusColors: Record<PostStatus, 'default' | 'info' | 'success' | 'error'> = {
   draft: 'default',
@@ -22,6 +28,11 @@ function formatDate(dateStr: string | null): string {
   return new Date(dateStr).toLocaleString();
 }
 
+type ConversationMessage = {
+  role: 'user' | 'assistant';
+  content: string;
+};
+
 type PostCardProps = {
   post: Post;
 };
@@ -29,7 +40,22 @@ type PostCardProps = {
 export default function PostCard({ post }: PostCardProps) {
   const [isEditing, setIsEditing] = useState(false);
   const [editContent, setEditContent] = useState(post.content);
+  const [tweakOpen, setTweakOpen] = useState(false);
+  const [tweakFeedback, setTweakFeedback] = useState('');
+  const [tweakCurrent, setTweakCurrent] = useState(post.content);
+  const [conversation, setConversation] = useState<ConversationMessage[]>([]);
+  const [successMessage, setSuccessMessage] = useState('');
+  const conversationEndRef = useRef<HTMLDivElement>(null);
+
   const updatePost = useUpdatePost();
+  const tweakPost = useTweakPost();
+  const acceptTweak = useAcceptTweak();
+
+  useEffect(() => {
+    if (conversationEndRef.current) {
+      conversationEndRef.current.scrollIntoView({ behavior: 'smooth' });
+    }
+  }, [conversation]);
 
   const handleSave = () => {
     updatePost.mutate(
@@ -57,6 +83,70 @@ export default function PostCard({ post }: PostCardProps) {
 
   const handleRatingChange = (_event: React.SyntheticEvent, value: number | null) => {
     updatePost.mutate({ id: post.id, rating: value });
+  };
+
+  const handleOpenTweak = () => {
+    setTweakCurrent(post.content);
+    setConversation([{ role: 'user', content: `Current tweet:\n${post.content}` }]);
+    setTweakFeedback('');
+    setSuccessMessage('');
+    setTweakOpen(true);
+  };
+
+  const handleCloseTweak = () => {
+    setTweakOpen(false);
+    setTweakFeedback('');
+    setConversation([]);
+    setSuccessMessage('');
+  };
+
+  const handleTweak = () => {
+    if (!tweakFeedback.trim()) return;
+
+    const feedbackText = tweakFeedback.trim();
+    setTweakFeedback('');
+
+    tweakPost.mutate(
+      {
+        postId: post.id,
+        feedback: feedbackText,
+        previousMessages: conversation.length > 0 ? conversation : undefined,
+      },
+      {
+        onSuccess: (data) => {
+          setTweakCurrent(data.content);
+          setConversation((prev) => [
+            ...prev,
+            { role: 'user' as const, content: `Feedback: ${feedbackText}` },
+            { role: 'assistant' as const, content: data.content },
+          ]);
+        },
+      },
+    );
+  };
+
+  const handleAcceptTweak = () => {
+    acceptTweak.mutate(
+      {
+        postId: post.id,
+        content: tweakCurrent,
+        conversation,
+      },
+      {
+        onSuccess: (data) => {
+          if (data.newTips.length > 0) {
+            const tipTexts = data.newTips.map((t) => t.content).join(', ');
+            setSuccessMessage(`Post updated! New tips saved: ${tipTexts}`);
+          } else {
+            setSuccessMessage('Post updated successfully!');
+          }
+          // Close after short delay so user can see the message
+          setTimeout(() => {
+            handleCloseTweak();
+          }, 2000);
+        },
+      },
+    );
   };
 
   const ratingEnabled =
@@ -135,6 +225,9 @@ export default function PostCard({ post }: PostCardProps) {
                 <Button size="small" variant="outlined" onClick={() => setIsEditing(true)}>
                   Edit
                 </Button>
+                <Button size="small" variant="outlined" onClick={handleOpenTweak}>
+                  Tweak
+                </Button>
                 <Button
                   size="small"
                   variant="contained"
@@ -166,6 +259,97 @@ export default function PostCard({ post }: PostCardProps) {
           </Box>
         </Box>
       </CardContent>
+
+      {/* Tweak Dialog */}
+      <Dialog open={tweakOpen} onClose={handleCloseTweak} maxWidth="sm" fullWidth>
+        <DialogTitle>Tweak Post</DialogTitle>
+        <DialogContent>
+          {successMessage && (
+            <Alert severity="success" sx={{ mb: 2 }}>
+              {successMessage}
+            </Alert>
+          )}
+
+          <Typography variant="subtitle2" sx={{ mb: 1, mt: 1 }}>
+            Current version:
+          </Typography>
+          <Card variant="outlined" sx={{ mb: 2, p: 2 }}>
+            <Typography variant="body2" sx={{ whiteSpace: 'pre-wrap' }}>
+              {tweakCurrent}
+            </Typography>
+          </Card>
+
+          {conversation.length > 1 && (
+            <>
+              <Typography variant="subtitle2" sx={{ mb: 1 }}>
+                Conversation:
+              </Typography>
+              <Box
+                sx={{
+                  maxHeight: 200,
+                  overflowY: 'auto',
+                  mb: 2,
+                  border: '1px solid',
+                  borderColor: 'divider',
+                  borderRadius: 1,
+                  p: 1,
+                }}
+              >
+                {conversation.slice(1).map((msg, idx) => (
+                  <Box
+                    key={idx}
+                    sx={{
+                      mb: 1,
+                      p: 1,
+                      borderRadius: 1,
+                      bgcolor: msg.role === 'user' ? 'action.hover' : 'primary.50',
+                    }}
+                  >
+                    <Typography variant="caption" color="text.secondary">
+                      {msg.role === 'user' ? 'You' : 'AI'}:
+                    </Typography>
+                    <Typography variant="body2" sx={{ whiteSpace: 'pre-wrap' }}>
+                      {msg.content}
+                    </Typography>
+                  </Box>
+                ))}
+                <div ref={conversationEndRef} />
+              </Box>
+            </>
+          )}
+
+          <TextField
+            fullWidth
+            multiline
+            minRows={2}
+            label="Feedback"
+            placeholder="e.g., make it more casual, add a question at the end"
+            value={tweakFeedback}
+            onChange={(e) => setTweakFeedback(e.target.value)}
+            disabled={tweakPost.isPending || acceptTweak.isPending}
+            sx={{ mt: 1 }}
+          />
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={handleCloseTweak} disabled={tweakPost.isPending || acceptTweak.isPending}>
+            Cancel
+          </Button>
+          <Button
+            variant="outlined"
+            onClick={handleTweak}
+            disabled={!tweakFeedback.trim() || tweakPost.isPending || acceptTweak.isPending}
+          >
+            {tweakPost.isPending ? <CircularProgress size={20} /> : 'Tweak'}
+          </Button>
+          <Button
+            variant="contained"
+            onClick={handleAcceptTweak}
+            disabled={conversation.length <= 1 || acceptTweak.isPending || tweakPost.isPending}
+          >
+            {acceptTweak.isPending ? <CircularProgress size={20} /> : 'Accept'}
+          </Button>
+        </DialogActions>
+      </Dialog>
     </Card>
   );
 }

--- a/web/src/hooks/useBot.ts
+++ b/web/src/hooks/useBot.ts
@@ -179,3 +179,67 @@ export function useUnshareBot() {
     },
   });
 }
+
+export type BotTip = {
+  id: string;
+  botId: string;
+  content: string;
+  createdAt: string;
+};
+
+type BotTipListResponse = {
+  data: BotTip[];
+};
+
+export function useBotTips(botId: string | undefined) {
+  return useQuery({
+    queryKey: queryKeys.bots.tips(botId ?? ''),
+    queryFn: async () => {
+      const response = await apiClient.get<BotTipListResponse>(`/bots/${botId}/tips`);
+      return response.data.data;
+    },
+    enabled: !!botId,
+  });
+}
+
+export function useUpdateTip() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({
+      botId,
+      tipId,
+      content,
+    }: {
+      botId: string;
+      tipId: string;
+      content: string;
+    }) => {
+      const response = await apiClient.patch<{ data: BotTip }>(
+        `/bots/${botId}/tips/${tipId}`,
+        { content },
+      );
+      return response.data.data;
+    },
+    onSuccess: (_data, variables) => {
+      void queryClient.invalidateQueries({
+        queryKey: queryKeys.bots.tips(variables.botId),
+      });
+    },
+  });
+}
+
+export function useDeleteTip() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({ botId, tipId }: { botId: string; tipId: string }) => {
+      await apiClient.delete(`/bots/${botId}/tips/${tipId}`);
+    },
+    onSuccess: (_data, variables) => {
+      void queryClient.invalidateQueries({
+        queryKey: queryKeys.bots.tips(variables.botId),
+      });
+    },
+  });
+}

--- a/web/src/hooks/usePosts.ts
+++ b/web/src/hooks/usePosts.ts
@@ -64,3 +64,59 @@ export function useUpdatePost() {
     },
   });
 }
+
+type TweakPostInput = {
+  postId: string;
+  feedback: string;
+  previousMessages?: Array<{ role: 'user' | 'assistant'; content: string }>;
+};
+
+type TweakPostResponse = {
+  data: { content: string };
+};
+
+export function useTweakPost() {
+  return useMutation({
+    mutationFn: async ({ postId, feedback, previousMessages }: TweakPostInput) => {
+      const response = await apiClient.post<TweakPostResponse>(`/posts/${postId}/tweak`, {
+        feedback,
+        previousMessages,
+      });
+      return response.data.data;
+    },
+  });
+}
+
+type BotTip = {
+  id: string;
+  botId: string;
+  content: string;
+  createdAt: string;
+};
+
+type AcceptTweakInput = {
+  postId: string;
+  content: string;
+  conversation: Array<{ role: string; content: string }>;
+};
+
+type AcceptTweakResponse = {
+  data: { post: Post; newTips: BotTip[] };
+};
+
+export function useAcceptTweak() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({ postId, content, conversation }: AcceptTweakInput) => {
+      const response = await apiClient.post<AcceptTweakResponse>(
+        `/posts/${postId}/accept-tweak`,
+        { content, conversation },
+      );
+      return response.data.data;
+    },
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: queryKeys.posts.all });
+    },
+  });
+}

--- a/web/src/lib/queryKeys.ts
+++ b/web/src/lib/queryKeys.ts
@@ -6,6 +6,7 @@ export const queryKeys = {
     list: ['bots', 'list'] as const,
     detail: (id: string) => ['bots', 'detail', id] as const,
     shares: (botId: string) => ['bots', 'shares', botId] as const,
+    tips: (botId: string) => ['bots', 'tips', botId] as const,
   },
   posts: {
     list: (status?: string, page?: number, showAll?: boolean) =>

--- a/web/src/pages/DashboardPage.tsx
+++ b/web/src/pages/DashboardPage.tsx
@@ -26,6 +26,9 @@ import TextField from '@mui/material/TextField';
 import Typography from '@mui/material/Typography';
 import CircularProgress from '@mui/material/CircularProgress';
 import DeleteIcon from '@mui/icons-material/Delete';
+import EditIcon from '@mui/icons-material/Edit';
+import CheckIcon from '@mui/icons-material/Check';
+import CloseIcon from '@mui/icons-material/Close';
 import AppHeader from '../components/AppHeader';
 import BotSetupForm from '../components/BotSetupForm';
 import {
@@ -35,6 +38,9 @@ import {
   useBotShares,
   useShareBot,
   useUnshareBot,
+  useBotTips,
+  useUpdateTip,
+  useDeleteTip,
 } from '../hooks/useBot';
 import { useAuth } from '../hooks/useAuth';
 import { useStats } from '../hooks/useStats';
@@ -93,6 +99,13 @@ export default function DashboardPage() {
   const { data: shares } = useBotShares(bot?.id);
   const shareBot = useShareBot();
   const unshareBot = useUnshareBot();
+
+  const { data: tips } = useBotTips(bot?.id);
+  const updateTip = useUpdateTip();
+  const deleteTip = useDeleteTip();
+  const [editingTipId, setEditingTipId] = useState<string | null>(null);
+  const [editingTipContent, setEditingTipContent] = useState('');
+  const [deleteConfirmTipId, setDeleteConfirmTipId] = useState<string | null>(null);
 
   const { data: stats, isLoading: statsLoading } = useStats(bot?.id);
   const { data: recentPostsData, isLoading: recentPostsLoading } = usePosts(undefined, 1, 5);
@@ -420,6 +433,134 @@ export default function DashboardPage() {
             </CardContent>
           </Card>
         )}
+
+        {/* Memory Tips */}
+        <Typography variant="h6" gutterBottom>
+          Memory Tips {tips && tips.length > 0 && `(${tips.length})`}
+        </Typography>
+        <Card sx={{ mb: 3 }}>
+          <CardContent>
+            {tips && tips.length > 0 ? (
+              <List dense disablePadding>
+                {tips.map((tip, index) => (
+                  <div key={tip.id}>
+                    {index > 0 && <Divider />}
+                    <ListItem
+                      secondaryAction={
+                        editingTipId === tip.id ? (
+                          <Box sx={{ display: 'flex', gap: 0.5 }}>
+                            <IconButton
+                              edge="end"
+                              size="small"
+                              onClick={() => {
+                                updateTip.mutate(
+                                  {
+                                    botId: bot!.id,
+                                    tipId: tip.id,
+                                    content: editingTipContent,
+                                  },
+                                  {
+                                    onSuccess: () => {
+                                      setEditingTipId(null);
+                                      showSnackbar('Tip updated', 'success');
+                                    },
+                                    onError: () => showSnackbar('Failed to update tip', 'error'),
+                                  },
+                                );
+                              }}
+                              disabled={updateTip.isPending}
+                            >
+                              <CheckIcon fontSize="small" />
+                            </IconButton>
+                            <IconButton
+                              edge="end"
+                              size="small"
+                              onClick={() => setEditingTipId(null)}
+                            >
+                              <CloseIcon fontSize="small" />
+                            </IconButton>
+                          </Box>
+                        ) : (
+                          <Box sx={{ display: 'flex', gap: 0.5 }}>
+                            <IconButton
+                              edge="end"
+                              size="small"
+                              onClick={() => {
+                                setEditingTipId(tip.id);
+                                setEditingTipContent(tip.content);
+                              }}
+                            >
+                              <EditIcon fontSize="small" />
+                            </IconButton>
+                            <IconButton
+                              edge="end"
+                              size="small"
+                              onClick={() => setDeleteConfirmTipId(tip.id)}
+                            >
+                              <DeleteIcon fontSize="small" />
+                            </IconButton>
+                          </Box>
+                        )
+                      }
+                    >
+                      {editingTipId === tip.id ? (
+                        <TextField
+                          fullWidth
+                          size="small"
+                          value={editingTipContent}
+                          onChange={(e) => setEditingTipContent(e.target.value)}
+                          sx={{ mr: 2 }}
+                        />
+                      ) : (
+                        <ListItemText primary={tip.content} />
+                      )}
+                    </ListItem>
+                  </div>
+                ))}
+              </List>
+            ) : (
+              <Typography variant="body2" color="text.secondary">
+                No memory tips yet. Tips are generated when you tweak and accept posts.
+              </Typography>
+            )}
+          </CardContent>
+        </Card>
+
+        {/* Delete tip confirmation dialog */}
+        <Dialog
+          open={!!deleteConfirmTipId}
+          onClose={() => setDeleteConfirmTipId(null)}
+        >
+          <DialogTitle>Delete Tip</DialogTitle>
+          <DialogContent>
+            <DialogContentText>
+              Are you sure you want to delete this memory tip?
+            </DialogContentText>
+          </DialogContent>
+          <DialogActions>
+            <Button onClick={() => setDeleteConfirmTipId(null)}>Cancel</Button>
+            <Button
+              variant="contained"
+              color="error"
+              disabled={deleteTip.isPending}
+              onClick={() => {
+                if (!deleteConfirmTipId || !bot) return;
+                deleteTip.mutate(
+                  { botId: bot.id, tipId: deleteConfirmTipId },
+                  {
+                    onSuccess: () => {
+                      setDeleteConfirmTipId(null);
+                      showSnackbar('Tip deleted', 'success');
+                    },
+                    onError: () => showSnackbar('Failed to delete tip', 'error'),
+                  },
+                );
+              }}
+            >
+              Delete
+            </Button>
+          </DialogActions>
+        </Dialog>
 
         {/* Quick Actions */}
         <Typography variant="h6" gutterBottom>


### PR DESCRIPTION
## Summary
- Add AI-powered post tweaking: users can iteratively refine draft posts with feedback, viewing the conversation history in a dialog
- On accepting a tweaked post, AI analyzes the conversation to generate 1-3 memory "tips" that guide future tweet generation for that bot
- Tips are manageable (view/edit/delete) on the bot dashboard page
- Tips are automatically included in the system prompt when generating new tweets

## Changes
- **API**: New `BotTip` model, repository, controller, and routes for tips CRUD
- **API**: New `tweakPost` and `acceptTweak` endpoints on posts, with service layer and AI integration
- **API**: Updated `generateTweet` to accept optional tips array
- **Web**: Tweak dialog on PostCard with conversation history, feedback input, and accept flow
- **Web**: Tips management section on DashboardPage with edit/delete
- **Web**: New hooks for tips and post tweaking mutations

## Test plan
- [ ] Create a draft post, click "Tweak", provide feedback, verify revised content appears
- [ ] Send multiple rounds of feedback, verify conversation history displays correctly
- [ ] Accept a tweaked post, verify tips are generated and shown in success message
- [ ] Navigate to bot dashboard, verify tips appear and can be edited/deleted
- [ ] Generate a new post for a bot with tips, verify tips influence the output
- [ ] Verify shared users can also tweak posts and manage tips

🤖 Generated with [Claude Code](https://claude.com/claude-code)