### PR TITLE
feat: practice drafts, conversational tweaking, 10-tip limit

### DIFF
--- a/api/prisma/migrations/20260314030000_make_post_job_optional/migration.sql
+++ b/api/prisma/migrations/20260314030000_make_post_job_optional/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Post" ALTER COLUMN "jobId" DROP NOT NULL;

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -57,7 +57,7 @@ model BotShare {
 model Post {
   id          String    @id @default(uuid()) @db.Uuid
   botId       String    @db.Uuid
-  jobId       String    @db.Uuid
+  jobId       String?   @db.Uuid
   content     String    @db.Text
   status      String    @default("draft")
   rating      Int?
@@ -66,7 +66,7 @@ model Post {
   createdAt   DateTime  @default(now())
 
   bot Bot @relation(fields: [botId], references: [id])
-  job Job @relation(fields: [jobId], references: [id])
+  job Job? @relation(fields: [jobId], references: [id])
 
   @@index([botId, status])
   @@index([status, scheduledAt])

--- a/api/src/controllers/botController.ts
+++ b/api/src/controllers/botController.ts
@@ -1,6 +1,9 @@
 import { Request, Response, NextFunction } from 'express';
 import { z } from 'zod';
 import { botService } from '../services/botService.js';
+import { generateTweet } from '../services/aiService.js';
+import { postRepository } from '../repositories/postRepository.js';
+import { botTipRepository } from '../repositories/botTipRepository.js';
 import { paginationSchema, uuidSchema } from '../utils/validation.js';
 
 const createBotSchema = z.object({
@@ -82,6 +85,41 @@ export const botController = {
 
       res.status(200).json({
         data: bot,
+      });
+    } catch (err) {
+      next(err);
+    }
+  },
+
+  async generateDrafts(req: Request, res: Response, next: NextFunction): Promise<void> {
+    try {
+      const userId = req.userId!;
+      const { id } = botIdParamSchema.parse(req.params);
+      const countSchema = z.object({
+        count: z.number().int().min(1).max(5).default(3),
+      });
+      const { count } = countSchema.parse(req.body);
+
+      const bot = await botService.getBot(id, userId);
+
+      const tips = await botTipRepository.findByBotId(bot.id);
+      const tipContents = tips.map((t) => t.content);
+
+      const posts = [];
+      for (let i = 0; i < count; i++) {
+        const result = await generateTweet(bot.prompt, tipContents);
+        if (result.success) {
+          const post = await postRepository.create({
+            botId: bot.id,
+            content: result.content,
+            status: 'draft',
+          });
+          posts.push(post);
+        }
+      }
+
+      res.status(201).json({
+        data: posts,
       });
     } catch (err) {
       next(err);

--- a/api/src/repositories/botTipRepository.ts
+++ b/api/src/repositories/botTipRepository.ts
@@ -24,6 +24,10 @@ export const botTipRepository = {
     return created;
   },
 
+  async countByBotId(botId: string) {
+    return prisma.botTip.count({ where: { botId } });
+  },
+
   async findByBotId(botId: string) {
     return prisma.botTip.findMany({
       where: { botId },

--- a/api/src/repositories/postRepository.ts
+++ b/api/src/repositories/postRepository.ts
@@ -3,7 +3,7 @@ import { prisma } from '../utils/prisma.js';
 export const postRepository = {
   async create(data: {
     botId: string;
-    jobId: string;
+    jobId?: string;
     content: string;
     status: string;
     scheduledAt?: Date | null;
@@ -11,7 +11,7 @@ export const postRepository = {
     return prisma.post.create({
       data: {
         botId: data.botId,
-        jobId: data.jobId,
+        jobId: data.jobId ?? null,
         content: data.content,
         status: data.status,
         scheduledAt: data.scheduledAt ?? null,

--- a/api/src/routes/botRoutes.ts
+++ b/api/src/routes/botRoutes.ts
@@ -14,6 +14,9 @@ router.get('/', botController.list);
 router.get('/:id', botController.getById);
 router.patch('/:id', botController.update);
 
+// Generate practice drafts
+router.post('/:id/generate-drafts', botController.generateDrafts);
+
 // Share routes
 router.post('/:id/shares', botShareController.create);
 router.get('/:id/shares', botShareController.list);

--- a/api/src/services/aiService.ts
+++ b/api/src/services/aiService.ts
@@ -15,7 +15,15 @@ Rules:
 - Do not include quotation marks around the tweet
 - Output ONLY the tweet text, nothing else`;
 
-const TWEAK_SYSTEM_PROMPT = `You are helping revise a tweet. Given the current tweet and user feedback, output ONLY the revised tweet text (under 280 chars). Do not include quotation marks around the tweet.`;
+const TWEAK_SYSTEM_PROMPT = `You are a collaborative social media editor helping refine a tweet. Have a natural conversation with the user — explain your changes, ask clarifying questions, suggest alternatives, and be a helpful creative partner.
+
+IMPORTANT: Always end your response with the revised tweet on its own line after the marker "---TWEET---". The tweet must be under 280 characters.
+
+Example format:
+Great idea to make it punchier! I shortened the opening and added a hook question at the end. Want me to try a different angle?
+
+---TWEET---
+The actual revised tweet text here`;
 
 const TIPS_SYSTEM_PROMPT = `Analyze this conversation where a user refined a tweet draft. Extract 1-3 concise tips/preferences that should guide future tweet generation for this account. Each tip should be a single sentence. Output only the tips, one per line.`;
 
@@ -45,10 +53,11 @@ async function callClaudeWithMessages(
   client: Anthropic,
   systemPrompt: string,
   messages: Array<{ role: 'user' | 'assistant'; content: string }>,
+  maxTokens = 300,
 ): Promise<string> {
   const response = await client.messages.create({
     model: 'claude-sonnet-4-20250514',
-    max_tokens: 300,
+    max_tokens: maxTokens,
     system: systemPrompt,
     messages,
   });
@@ -97,7 +106,7 @@ export async function tweakPost(
   currentContent: string,
   feedback: string,
   previousMessages?: Array<{ role: 'user' | 'assistant'; content: string }>,
-): Promise<string> {
+): Promise<{ message: string; content: string }> {
   const client = getClient();
   if (!client) {
     throw new Error('AI service not configured \u2014 set ANTHROPIC_API_KEY');
@@ -111,10 +120,20 @@ export async function tweakPost(
     messages.push({ role: 'user', content: `Current tweet:\n${currentContent}` });
   }
 
-  messages.push({ role: 'user', content: `Feedback: ${feedback}` });
+  messages.push({ role: 'user', content: feedback });
 
-  const revised = await callClaudeWithMessages(client, TWEAK_SYSTEM_PROMPT, messages);
-  return revised;
+  const response = await callClaudeWithMessages(client, TWEAK_SYSTEM_PROMPT, messages, 600);
+
+  const tweetMarker = '---TWEET---';
+  const markerIndex = response.indexOf(tweetMarker);
+  if (markerIndex === -1) {
+    // Fallback: treat entire response as the tweet (backward compat)
+    return { message: '', content: response };
+  }
+
+  const message = response.substring(0, markerIndex).trim();
+  const content = response.substring(markerIndex + tweetMarker.length).trim();
+  return { message, content };
 }
 
 export async function generateTips(

--- a/api/src/services/postService.ts
+++ b/api/src/services/postService.ts
@@ -108,8 +108,8 @@ export const postService = {
       throw new ValidationError('Only draft posts can be tweaked');
     }
 
-    const revised = await tweakPost(post.content, feedback, previousMessages);
-    return { content: revised };
+    const result = await tweakPost(post.content, feedback, previousMessages);
+    return result;
   },
 
   async acceptTweak(
@@ -131,17 +131,22 @@ export const postService = {
 
     const updatedPost = await postRepository.update(postId, { content });
 
-    // Generate tips from the conversation
+    // Generate tips from the conversation (max 10 per bot)
     let newTips: Array<{ id: string; botId: string; content: string; createdAt: Date }> = [];
     try {
-      const tipStrings = await generateTips(conversation);
-      if (tipStrings.length > 0) {
-        newTips = await botTipRepository.createMany(
-          tipStrings.map((tipContent) => ({
-            botId: post.botId,
-            content: tipContent,
-          })),
-        );
+      const existingCount = await botTipRepository.countByBotId(post.botId);
+      const slotsAvailable = Math.max(0, 10 - existingCount);
+      if (slotsAvailable > 0) {
+        const tipStrings = await generateTips(conversation);
+        const tipsToSave = tipStrings.slice(0, slotsAvailable);
+        if (tipsToSave.length > 0) {
+          newTips = await botTipRepository.createMany(
+            tipsToSave.map((tipContent) => ({
+              botId: post.botId,
+              content: tipContent,
+            })),
+          );
+        }
       }
     } catch {
       // Tips generation is best-effort; don't fail the accept

--- a/web/src/components/PostCard.tsx
+++ b/web/src/components/PostCard.tsx
@@ -87,7 +87,7 @@ export default function PostCard({ post }: PostCardProps) {
 
   const handleOpenTweak = () => {
     setTweakCurrent(post.content);
-    setConversation([{ role: 'user', content: `Current tweet:\n${post.content}` }]);
+    setConversation([]);
     setTweakFeedback('');
     setSuccessMessage('');
     setTweakOpen(true);
@@ -106,20 +106,36 @@ export default function PostCard({ post }: PostCardProps) {
     const feedbackText = tweakFeedback.trim();
     setTweakFeedback('');
 
+    // Build messages for the API — include the initial tweet context on first message
+    const apiMessages: ConversationMessage[] =
+      conversation.length === 0
+        ? [{ role: 'user', content: `Current tweet:\n${post.content}` }]
+        : [...conversation];
+
     tweakPost.mutate(
       {
         postId: post.id,
         feedback: feedbackText,
-        previousMessages: conversation.length > 0 ? conversation : undefined,
+        previousMessages: apiMessages,
       },
       {
         onSuccess: (data) => {
           setTweakCurrent(data.content);
-          setConversation((prev) => [
-            ...prev,
-            { role: 'user' as const, content: `Feedback: ${feedbackText}` },
-            { role: 'assistant' as const, content: data.content },
-          ]);
+          // Store the full AI response (message + tweet) for conversation continuity
+          const aiResponse = data.message
+            ? `${data.message}\n\n---TWEET---\n${data.content}`
+            : data.content;
+          setConversation((prev) => {
+            const base =
+              prev.length === 0
+                ? [{ role: 'user' as const, content: `Current tweet:\n${post.content}` }]
+                : prev;
+            return [
+              ...base,
+              { role: 'user' as const, content: feedbackText },
+              { role: 'assistant' as const, content: aiResponse },
+            ];
+          });
         },
       },
     );
@@ -286,7 +302,7 @@ export default function PostCard({ post }: PostCardProps) {
               </Typography>
               <Box
                 sx={{
-                  maxHeight: 200,
+                  maxHeight: 300,
                   overflowY: 'auto',
                   mb: 2,
                   border: '1px solid',
@@ -295,24 +311,35 @@ export default function PostCard({ post }: PostCardProps) {
                   p: 1,
                 }}
               >
-                {conversation.slice(1).map((msg, idx) => (
-                  <Box
-                    key={idx}
-                    sx={{
-                      mb: 1,
-                      p: 1,
-                      borderRadius: 1,
-                      bgcolor: msg.role === 'user' ? 'action.hover' : 'primary.50',
-                    }}
-                  >
-                    <Typography variant="caption" color="text.secondary">
-                      {msg.role === 'user' ? 'You' : 'AI'}:
-                    </Typography>
-                    <Typography variant="body2" sx={{ whiteSpace: 'pre-wrap' }}>
-                      {msg.content}
-                    </Typography>
-                  </Box>
-                ))}
+                {conversation.slice(1).map((msg, idx) => {
+                  // For AI messages, strip the ---TWEET--- portion for display
+                  let displayContent = msg.content;
+                  if (msg.role === 'assistant') {
+                    const markerIdx = msg.content.indexOf('---TWEET---');
+                    if (markerIdx !== -1) {
+                      displayContent = msg.content.substring(0, markerIdx).trim();
+                    }
+                  }
+                  if (!displayContent) return null;
+                  return (
+                    <Box
+                      key={idx}
+                      sx={{
+                        mb: 1,
+                        p: 1.5,
+                        borderRadius: 1,
+                        bgcolor: msg.role === 'user' ? 'action.hover' : 'primary.50',
+                      }}
+                    >
+                      <Typography variant="caption" color="text.secondary" fontWeight="bold">
+                        {msg.role === 'user' ? 'You' : 'AI'}
+                      </Typography>
+                      <Typography variant="body2" sx={{ whiteSpace: 'pre-wrap', mt: 0.5 }}>
+                        {displayContent}
+                      </Typography>
+                    </Box>
+                  );
+                })}
                 <div ref={conversationEndRef} />
               </Box>
             </>
@@ -322,10 +349,16 @@ export default function PostCard({ post }: PostCardProps) {
             fullWidth
             multiline
             minRows={2}
-            label="Feedback"
-            placeholder="e.g., make it more casual, add a question at the end"
+            label="Your message"
+            placeholder="e.g., make it more casual, add a question at the end..."
             value={tweakFeedback}
             onChange={(e) => setTweakFeedback(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' && !e.shiftKey) {
+                e.preventDefault();
+                handleTweak();
+              }
+            }}
             disabled={tweakPost.isPending || acceptTweak.isPending}
             sx={{ mt: 1 }}
           />
@@ -339,12 +372,12 @@ export default function PostCard({ post }: PostCardProps) {
             onClick={handleTweak}
             disabled={!tweakFeedback.trim() || tweakPost.isPending || acceptTweak.isPending}
           >
-            {tweakPost.isPending ? <CircularProgress size={20} /> : 'Tweak'}
+            {tweakPost.isPending ? <CircularProgress size={20} /> : 'Send'}
           </Button>
           <Button
             variant="contained"
             onClick={handleAcceptTweak}
-            disabled={conversation.length <= 1 || acceptTweak.isPending || tweakPost.isPending}
+            disabled={conversation.length === 0 || acceptTweak.isPending || tweakPost.isPending}
           >
             {acceptTweak.isPending ? <CircularProgress size={20} /> : 'Accept'}
           </Button>

--- a/web/src/hooks/useBot.ts
+++ b/web/src/hooks/useBot.ts
@@ -136,6 +136,23 @@ export function useUpdateBot() {
   });
 }
 
+export function useGenerateDrafts() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({ botId, count = 3 }: { botId: string; count?: number }) => {
+      const response = await apiClient.post<{ data: Array<{ id: string; content: string }> }>(
+        `/bots/${botId}/generate-drafts`,
+        { count },
+      );
+      return response.data.data;
+    },
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: queryKeys.posts.all });
+    },
+  });
+}
+
 export function useBotShares(botId: string | undefined) {
   return useQuery({
     queryKey: queryKeys.bots.shares(botId ?? ''),

--- a/web/src/hooks/usePosts.ts
+++ b/web/src/hooks/usePosts.ts
@@ -72,7 +72,7 @@ type TweakPostInput = {
 };
 
 type TweakPostResponse = {
-  data: { content: string };
+  data: { message: string; content: string };
 };
 
 export function useTweakPost() {

--- a/web/src/pages/DashboardPage.tsx
+++ b/web/src/pages/DashboardPage.tsx
@@ -35,6 +35,7 @@ import {
   useBot,
   useCreateBot,
   useUpdateBot,
+  useGenerateDrafts,
   useBotShares,
   useShareBot,
   useUnshareBot,
@@ -95,6 +96,8 @@ export default function DashboardPage() {
 
   const bot = bots.length > 0 ? bots[Math.min(selectedBotIndex, bots.length - 1)] : null;
   const isOwner = bot ? bot.userId === user?.id : false;
+
+  const generateDrafts = useGenerateDrafts();
 
   const { data: shares } = useBotShares(bot?.id);
   const shareBot = useShareBot();
@@ -436,7 +439,7 @@ export default function DashboardPage() {
 
         {/* Memory Tips */}
         <Typography variant="h6" gutterBottom>
-          Memory Tips {tips && tips.length > 0 && `(${tips.length})`}
+          Memory Tips {tips && `(${tips.length}/10)`}
         </Typography>
         <Card sx={{ mb: 3 }}>
           <CardContent>
@@ -507,6 +510,9 @@ export default function DashboardPage() {
                         <TextField
                           fullWidth
                           size="small"
+                          multiline
+                          minRows={2}
+                          maxRows={6}
                           value={editingTipContent}
                           onChange={(e) => setEditingTipContent(e.target.value)}
                           sx={{ mr: 2 }}
@@ -567,7 +573,34 @@ export default function DashboardPage() {
           Quick Actions
         </Typography>
         <Box sx={{ display: 'flex', gap: 2, mb: 4 }}>
-          <Button variant="contained" onClick={() => void navigate({ to: '/posts' })}>
+          <Button
+            variant="contained"
+            disabled={generateDrafts.isPending}
+            onClick={() => {
+              if (!bot) return;
+              generateDrafts.mutate(
+                { botId: bot.id, count: 3 },
+                {
+                  onSuccess: (posts) => {
+                    showSnackbar(`Generated ${posts.length} practice draft(s)`, 'success');
+                  },
+                  onError: () => {
+                    showSnackbar('Failed to generate drafts', 'error');
+                  },
+                },
+              );
+            }}
+          >
+            {generateDrafts.isPending ? (
+              <>
+                <CircularProgress size={18} sx={{ mr: 1 }} />
+                Generating...
+              </>
+            ) : (
+              'Generate Practice Drafts'
+            )}
+          </Button>
+          <Button variant="outlined" onClick={() => void navigate({ to: '/posts' })}>
             View Post Queue
           </Button>
           <Button variant="outlined" onClick={() => setEditOpen(true)}>


### PR DESCRIPTION
## Summary
- **Generate Practice Drafts**: button on dashboard creates 3 AI-generated draft posts using bot prompt + memory tips, for tweaking practice (never auto-published)
- **Conversational tweaking**: AI now responds conversationally when tweaking posts — explains changes, asks questions, suggests alternatives — while showing the revised tweet separately
- **10-tip limit**: max 10 memory tips per bot, enforced on generation; dashboard shows (N/10) count
- **Textarea for tips**: tip editing now uses a multiline textarea instead of single-line input
- **Schema change**: `jobId` on Post is now optional to support practice drafts without jobs

## Test plan
- [ ] Click "Generate Practice Drafts" on dashboard, verify 3 draft posts are created
- [ ] Tweak a draft post — verify AI responds conversationally with explanations
- [ ] Verify revised tweet shows separately in "Current version" card
- [ ] Accept a tweak, verify tips are capped at 10 per bot
- [ ] Edit a memory tip, verify textarea is multiline
- [ ] Verify existing job-based post creation still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)