### PR TITLE
feat: add judge system for AI-powered post review

### DIFF
--- a/api/prisma/migrations/20260314040000_add_judge_system/migration.sql
+++ b/api/prisma/migrations/20260314040000_add_judge_system/migration.sql
@@ -1,0 +1,55 @@
+-- CreateTable
+CREATE TABLE "Judge" (
+    "id" UUID NOT NULL DEFAULT gen_random_uuid(),
+    "name" TEXT NOT NULL,
+    "prompt" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "Judge_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "BotJudge" (
+    "id" UUID NOT NULL DEFAULT gen_random_uuid(),
+    "botId" UUID NOT NULL,
+    "judgeId" UUID NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "BotJudge_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "BotJudge_botId_judgeId_key" ON "BotJudge"("botId", "judgeId");
+
+-- AddForeignKey
+ALTER TABLE "BotJudge" ADD CONSTRAINT "BotJudge_botId_fkey" FOREIGN KEY ("botId") REFERENCES "Bot"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "BotJudge" ADD CONSTRAINT "BotJudge_judgeId_fkey" FOREIGN KEY ("judgeId") REFERENCES "Judge"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- CreateTable
+CREATE TABLE "PostReview" (
+    "id" UUID NOT NULL DEFAULT gen_random_uuid(),
+    "postId" UUID NOT NULL,
+    "judgeId" UUID NOT NULL,
+    "rating" INTEGER NOT NULL,
+    "opinion" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "PostReview_pkey" PRIMARY KEY ("id")
+);
+
+-- AddForeignKey
+ALTER TABLE "PostReview" ADD CONSTRAINT "PostReview_postId_fkey" FOREIGN KEY ("postId") REFERENCES "Post"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "PostReview" ADD CONSTRAINT "PostReview_judgeId_fkey" FOREIGN KEY ("judgeId") REFERENCES "Judge"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- Seed default judges
+INSERT INTO "Judge" ("id", "name", "prompt") VALUES
+  (gen_random_uuid(), 'Junior Engineer', 'You are a junior software engineer who is worried about your career in an AI-dominated world. You evaluate content through the lens of someone early in their tech career, anxious about relevance and job security.'),
+  (gen_random_uuid(), 'Senior Engineer', 'You are a senior software engineer who does not like AI. You are skeptical of AI hype and prefer proven, human-crafted approaches. You evaluate content with a critical, experience-driven perspective.'),
+  (gen_random_uuid(), 'Non-Technical CTO', 'You are a non-technical CTO running a large engineering team. You focus on leadership, team dynamics, and business outcomes rather than technical details. You evaluate content from a management and strategy perspective.'),
+  (gen_random_uuid(), 'Technical CTO', 'You are a technical CTO with too much to do and no time to think. You are overwhelmed but deeply knowledgeable. You evaluate content for practical value and time-efficiency.'),
+  (gen_random_uuid(), 'Skeptical Investor', 'You are a skeptical investor who is unsure if your tech investments are paying off because you do not fully understand the technology. You evaluate content for clarity, ROI signals, and whether it helps you understand the tech landscape.'),
+  (gen_random_uuid(), 'Talent-Focused Investor', 'You are an investor focused on helping startups succeed by bringing in the best talent. You evaluate content through the lens of talent acquisition, team building, and startup growth.');

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -35,11 +35,12 @@ model Bot {
   active              Boolean  @default(true)
   createdAt           DateTime @default(now())
 
-  user   User       @relation(fields: [userId], references: [id])
-  posts  Post[]
-  jobs   Job[]
-  shares BotShare[]
-  tips   BotTip[]
+  user      User       @relation(fields: [userId], references: [id])
+  posts     Post[]
+  jobs      Job[]
+  shares    BotShare[]
+  tips      BotTip[]
+  botJudges BotJudge[]
 }
 
 model BotShare {
@@ -65,8 +66,9 @@ model Post {
   publishedAt DateTime?
   createdAt   DateTime  @default(now())
 
-  bot Bot @relation(fields: [botId], references: [id])
-  job Job? @relation(fields: [jobId], references: [id])
+  bot     Bot          @relation(fields: [botId], references: [id])
+  job     Job?         @relation(fields: [jobId], references: [id])
+  reviews PostReview[]
 
   @@index([botId, status])
   @@index([status, scheduledAt])
@@ -98,4 +100,38 @@ model Job {
 
   @@index([status, scheduledAt])
   @@index([status, lockedAt])
+}
+
+model Judge {
+  id        String   @id @default(uuid()) @db.Uuid
+  name      String
+  prompt    String   @db.Text
+  createdAt DateTime @default(now())
+
+  botJudges BotJudge[]
+  reviews   PostReview[]
+}
+
+model BotJudge {
+  id        String   @id @default(uuid()) @db.Uuid
+  botId     String   @db.Uuid
+  judgeId   String   @db.Uuid
+  createdAt DateTime @default(now())
+
+  bot   Bot   @relation(fields: [botId], references: [id])
+  judge Judge @relation(fields: [judgeId], references: [id])
+
+  @@unique([botId, judgeId])
+}
+
+model PostReview {
+  id        String   @id @default(uuid()) @db.Uuid
+  postId    String   @db.Uuid
+  judgeId   String   @db.Uuid
+  rating    Int
+  opinion   String   @db.Text
+  createdAt DateTime @default(now())
+
+  post  Post  @relation(fields: [postId], references: [id])
+  judge Judge @relation(fields: [judgeId], references: [id])
 }

--- a/api/src/controllers/botJudgeController.ts
+++ b/api/src/controllers/botJudgeController.ts
@@ -1,0 +1,100 @@
+import { Request, Response, NextFunction } from 'express';
+import { z } from 'zod';
+import { botJudgeRepository } from '../repositories/botJudgeRepository.js';
+import { botRepository } from '../repositories/botRepository.js';
+import { botShareRepository } from '../repositories/botShareRepository.js';
+import { judgeRepository } from '../repositories/judgeRepository.js';
+import { uuidSchema } from '../utils/validation.js';
+import { NotFoundError, ForbiddenError, ValidationError } from '../utils/errors.js';
+
+const botIdParamSchema = z.object({
+  id: uuidSchema,
+});
+
+const botJudgeParamSchema = z.object({
+  id: uuidSchema,
+  judgeId: uuidSchema,
+});
+
+const assignJudgeSchema = z.object({
+  judgeId: uuidSchema,
+});
+
+async function assertBotAccess(botId: string, userId: string): Promise<void> {
+  const bot = await botRepository.findById(botId);
+  if (!bot) {
+    throw new NotFoundError('Bot not found');
+  }
+  if (bot.userId !== userId) {
+    const share = await botShareRepository.findByBotIdAndUserId(botId, userId);
+    if (!share) {
+      throw new ForbiddenError('You do not have access to this bot');
+    }
+  }
+}
+
+export const botJudgeController = {
+  async list(req: Request, res: Response, next: NextFunction): Promise<void> {
+    try {
+      const userId = req.userId!;
+      const { id } = botIdParamSchema.parse(req.params);
+      await assertBotAccess(id, userId);
+
+      const botJudges = await botJudgeRepository.findByBotId(id);
+      res.status(200).json({ data: botJudges });
+    } catch (err) {
+      next(err);
+    }
+  },
+
+  async assign(req: Request, res: Response, next: NextFunction): Promise<void> {
+    try {
+      const userId = req.userId!;
+      const { id } = botIdParamSchema.parse(req.params);
+      await assertBotAccess(id, userId);
+
+      const { judgeId } = assignJudgeSchema.parse(req.body);
+
+      // Verify judge exists
+      const judge = await judgeRepository.findById(judgeId);
+      if (!judge) {
+        throw new NotFoundError('Judge not found');
+      }
+
+      // Check max 5 judges per bot
+      const count = await botJudgeRepository.countByBotId(id);
+      if (count >= 5) {
+        throw new ValidationError('A bot can have at most 5 judges assigned');
+      }
+
+      // Check not already assigned
+      const existing = await botJudgeRepository.findByBotIdAndJudgeId(id, judgeId);
+      if (existing) {
+        throw new ValidationError('Judge is already assigned to this bot');
+      }
+
+      const botJudge = await botJudgeRepository.create({ botId: id, judgeId });
+      res.status(201).json({ data: botJudge });
+    } catch (err) {
+      next(err);
+    }
+  },
+
+  async remove(req: Request, res: Response, next: NextFunction): Promise<void> {
+    try {
+      const userId = req.userId!;
+      const { id, judgeId } = botJudgeParamSchema.parse(req.params);
+      await assertBotAccess(id, userId);
+
+      const existing = await botJudgeRepository.findByBotIdAndJudgeId(id, judgeId);
+      if (!existing) {
+        throw new NotFoundError('Judge assignment not found');
+      }
+
+      await botJudgeRepository.delete(id, judgeId);
+      res.status(204).send();
+    } catch (err) {
+      next(err);
+    }
+  },
+};

--- a/api/src/controllers/judgeController.ts
+++ b/api/src/controllers/judgeController.ts
@@ -1,0 +1,91 @@
+import { Request, Response, NextFunction } from 'express';
+import { z } from 'zod';
+import { judgeRepository } from '../repositories/judgeRepository.js';
+import { userRepository } from '../repositories/userRepository.js';
+import { uuidSchema } from '../utils/validation.js';
+import { ForbiddenError, NotFoundError } from '../utils/errors.js';
+
+const judgeIdParamSchema = z.object({
+  id: uuidSchema,
+});
+
+const createJudgeSchema = z.object({
+  name: z.string().min(1, 'Name must not be empty'),
+  prompt: z.string().min(1, 'Prompt must not be empty'),
+});
+
+const updateJudgeSchema = z.object({
+  name: z.string().min(1, 'Name must not be empty').optional(),
+  prompt: z.string().min(1, 'Prompt must not be empty').optional(),
+});
+
+async function assertAdmin(userId: string): Promise<void> {
+  const user = await userRepository.findById(userId);
+  if (!user?.isAdmin) {
+    throw new ForbiddenError('Admin access required');
+  }
+}
+
+export const judgeController = {
+  async list(_req: Request, res: Response, next: NextFunction): Promise<void> {
+    try {
+      const judges = await judgeRepository.findAll();
+      res.status(200).json({ data: judges });
+    } catch (err) {
+      next(err);
+    }
+  },
+
+  async create(req: Request, res: Response, next: NextFunction): Promise<void> {
+    try {
+      const userId = req.userId!;
+      await assertAdmin(userId);
+
+      const { name, prompt } = createJudgeSchema.parse(req.body);
+      const judge = await judgeRepository.create({ name, prompt });
+
+      res.status(201).json({ data: judge });
+    } catch (err) {
+      next(err);
+    }
+  },
+
+  async update(req: Request, res: Response, next: NextFunction): Promise<void> {
+    try {
+      const userId = req.userId!;
+      await assertAdmin(userId);
+
+      const { id } = judgeIdParamSchema.parse(req.params);
+      const body = updateJudgeSchema.parse(req.body);
+
+      const existing = await judgeRepository.findById(id);
+      if (!existing) {
+        throw new NotFoundError('Judge not found');
+      }
+
+      const judge = await judgeRepository.update(id, body);
+      res.status(200).json({ data: judge });
+    } catch (err) {
+      next(err);
+    }
+  },
+
+  async remove(req: Request, res: Response, next: NextFunction): Promise<void> {
+    try {
+      const userId = req.userId!;
+      await assertAdmin(userId);
+
+      const { id } = judgeIdParamSchema.parse(req.params);
+
+      const existing = await judgeRepository.findById(id);
+      if (!existing) {
+        throw new NotFoundError('Judge not found');
+      }
+
+      await judgeRepository.delete(id);
+      res.status(204).send();
+    } catch (err) {
+      next(err);
+    }
+  },
+};

--- a/api/src/controllers/postReviewController.ts
+++ b/api/src/controllers/postReviewController.ts
@@ -1,0 +1,79 @@
+import { Request, Response, NextFunction } from 'express';
+import { z } from 'zod';
+import { postReviewRepository } from '../repositories/postReviewRepository.js';
+import { postRepository } from '../repositories/postRepository.js';
+import { botJudgeRepository } from '../repositories/botJudgeRepository.js';
+import { botRepository } from '../repositories/botRepository.js';
+import { botShareRepository } from '../repositories/botShareRepository.js';
+import { uuidSchema } from '../utils/validation.js';
+import { NotFoundError, ForbiddenError, ValidationError } from '../utils/errors.js';
+import { reviewPostWithJudge } from '../services/judgeAiService.js';
+
+const postIdParamSchema = z.object({
+  id: uuidSchema,
+});
+
+async function assertPostAccess(postId: string, userId: string) {
+  const post = await postRepository.findById(postId);
+  if (!post) {
+    throw new NotFoundError('Post not found');
+  }
+  const bot = await botRepository.findById(post.botId);
+  if (!bot) {
+    throw new NotFoundError('Bot not found');
+  }
+  if (bot.userId !== userId) {
+    const share = await botShareRepository.findByBotIdAndUserId(post.botId, userId);
+    if (!share) {
+      throw new ForbiddenError('You do not have access to this post');
+    }
+  }
+  return post;
+}
+
+export const postReviewController = {
+  async list(req: Request, res: Response, next: NextFunction): Promise<void> {
+    try {
+      const userId = req.userId!;
+      const { id } = postIdParamSchema.parse(req.params);
+      await assertPostAccess(id, userId);
+
+      const reviews = await postReviewRepository.findByPostId(id);
+      res.status(200).json({ data: reviews });
+    } catch (err) {
+      next(err);
+    }
+  },
+
+  async review(req: Request, res: Response, next: NextFunction): Promise<void> {
+    try {
+      const userId = req.userId!;
+      const { id } = postIdParamSchema.parse(req.params);
+      const post = await assertPostAccess(id, userId);
+
+      // Get judges assigned to this bot
+      const botJudges = await botJudgeRepository.findByBotId(post.botId);
+      if (botJudges.length === 0) {
+        throw new ValidationError('No judges assigned to this bot. Assign judges first.');
+      }
+
+      // Call AI for each judge in parallel
+      const reviewPromises = botJudges.map(async (bj) => {
+        const result = await reviewPostWithJudge(bj.judge.name, bj.judge.prompt, post.content);
+        return {
+          postId: id,
+          judgeId: bj.judgeId,
+          rating: result.rating,
+          opinion: result.opinion,
+        };
+      });
+
+      const reviewResults = await Promise.all(reviewPromises);
+      const reviews = await postReviewRepository.createMany(reviewResults);
+
+      res.status(201).json({ data: reviews });
+    } catch (err) {
+      next(err);
+    }
+  },
+};

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -15,6 +15,7 @@ import postRoutes from './routes/postRoutes.js';
 import userRoutes from './routes/userRoutes.js';
 import statsRoutes from './routes/statsRoutes.js';
 import jobQueueRoutes from './routes/jobQueueRoutes.js';
+import judgeRoutes from './routes/judgeRoutes.js';
 import * as jobWorker from './worker/jobWorker.js';
 import * as staleLockRecovery from './worker/staleLockRecovery.js';
 import * as postPublisher from './worker/postPublisher.js';
@@ -43,6 +44,7 @@ app.use('/api/auth/x', xOAuthRoutes);
 app.use('/api/posts', postRoutes);
 app.use('/api/users', userRoutes);
 app.use('/api/jobs', jobQueueRoutes);
+app.use('/api/judges', judgeRoutes);
 
 // 404 handler for unknown routes
 app.use(notFoundHandler);

--- a/api/src/repositories/botJudgeRepository.ts
+++ b/api/src/repositories/botJudgeRepository.ts
@@ -1,0 +1,37 @@
+import { prisma } from '../utils/prisma.js';
+
+export const botJudgeRepository = {
+  async findByBotId(botId: string) {
+    return prisma.botJudge.findMany({
+      where: { botId },
+      include: { judge: true },
+      orderBy: { createdAt: 'asc' },
+    });
+  },
+
+  async countByBotId(botId: string) {
+    return prisma.botJudge.count({ where: { botId } });
+  },
+
+  async findByBotIdAndJudgeId(botId: string, judgeId: string) {
+    return prisma.botJudge.findUnique({
+      where: { botId_judgeId: { botId, judgeId } },
+    });
+  },
+
+  async create(data: { botId: string; judgeId: string }) {
+    return prisma.botJudge.create({
+      data: {
+        botId: data.botId,
+        judgeId: data.judgeId,
+      },
+      include: { judge: true },
+    });
+  },
+
+  async delete(botId: string, judgeId: string) {
+    return prisma.botJudge.delete({
+      where: { botId_judgeId: { botId, judgeId } },
+    });
+  },
+};

--- a/api/src/repositories/judgeRepository.ts
+++ b/api/src/repositories/judgeRepository.ts
@@ -1,0 +1,37 @@
+import { prisma } from '../utils/prisma.js';
+
+export const judgeRepository = {
+  async findAll() {
+    return prisma.judge.findMany({
+      orderBy: { createdAt: 'asc' },
+    });
+  },
+
+  async findById(id: string) {
+    return prisma.judge.findUnique({
+      where: { id },
+    });
+  },
+
+  async create(data: { name: string; prompt: string }) {
+    return prisma.judge.create({
+      data: {
+        name: data.name,
+        prompt: data.prompt,
+      },
+    });
+  },
+
+  async update(id: string, data: { name?: string; prompt?: string }) {
+    return prisma.judge.update({
+      where: { id },
+      data,
+    });
+  },
+
+  async delete(id: string) {
+    return prisma.judge.delete({
+      where: { id },
+    });
+  },
+};

--- a/api/src/repositories/postReviewRepository.ts
+++ b/api/src/repositories/postReviewRepository.ts
@@ -1,0 +1,40 @@
+import { prisma } from '../utils/prisma.js';
+
+export const postReviewRepository = {
+  async findByPostId(postId: string) {
+    return prisma.postReview.findMany({
+      where: { postId },
+      include: { judge: true },
+      orderBy: { createdAt: 'asc' },
+    });
+  },
+
+  async create(data: { postId: string; judgeId: string; rating: number; opinion: string }) {
+    return prisma.postReview.create({
+      data: {
+        postId: data.postId,
+        judgeId: data.judgeId,
+        rating: data.rating,
+        opinion: data.opinion,
+      },
+      include: { judge: true },
+    });
+  },
+
+  async createMany(reviews: Array<{ postId: string; judgeId: string; rating: number; opinion: string }>) {
+    const created = await Promise.all(
+      reviews.map((review) =>
+        prisma.postReview.create({
+          data: {
+            postId: review.postId,
+            judgeId: review.judgeId,
+            rating: review.rating,
+            opinion: review.opinion,
+          },
+          include: { judge: true },
+        }),
+      ),
+    );
+    return created;
+  },
+};

--- a/api/src/routes/botRoutes.ts
+++ b/api/src/routes/botRoutes.ts
@@ -2,6 +2,7 @@ import { Router } from 'express';
 import { botController } from '../controllers/botController.js';
 import { botShareController } from '../controllers/botShareController.js';
 import { botTipController } from '../controllers/botTipController.js';
+import { botJudgeController } from '../controllers/botJudgeController.js';
 import { authMiddleware } from '../middleware/auth.js';
 
 const router = Router();
@@ -26,5 +27,10 @@ router.delete('/:id/shares/:userId', botShareController.remove);
 router.get('/:id/tips', botTipController.list);
 router.patch('/:id/tips/:tipId', botTipController.update);
 router.delete('/:id/tips/:tipId', botTipController.remove);
+
+// Judge assignment routes
+router.get('/:id/judges', botJudgeController.list);
+router.post('/:id/judges', botJudgeController.assign);
+router.delete('/:id/judges/:judgeId', botJudgeController.remove);
 
 export default router;

--- a/api/src/routes/judgeRoutes.ts
+++ b/api/src/routes/judgeRoutes.ts
@@ -1,0 +1,14 @@
+import { Router } from 'express';
+import { judgeController } from '../controllers/judgeController.js';
+import { authMiddleware } from '../middleware/auth.js';
+
+const router = Router();
+
+router.use(authMiddleware);
+
+router.get('/', judgeController.list);
+router.post('/', judgeController.create);
+router.patch('/:id', judgeController.update);
+router.delete('/:id', judgeController.remove);
+
+export default router;

--- a/api/src/routes/postRoutes.ts
+++ b/api/src/routes/postRoutes.ts
@@ -1,5 +1,6 @@
 import { Router } from 'express';
 import { postController } from '../controllers/postController.js';
+import { postReviewController } from '../controllers/postReviewController.js';
 import { authMiddleware } from '../middleware/auth.js';
 
 const router = Router();
@@ -11,5 +12,9 @@ router.get('/', postController.list);
 router.patch('/:id', postController.update);
 router.post('/:id/tweak', postController.tweak);
 router.post('/:id/accept-tweak', postController.acceptTweak);
+
+// Review routes
+router.post('/:id/review', postReviewController.review);
+router.get('/:id/reviews', postReviewController.list);
 
 export default router;

--- a/api/src/services/judgeAiService.ts
+++ b/api/src/services/judgeAiService.ts
@@ -1,0 +1,53 @@
+import Anthropic from '@anthropic-ai/sdk';
+
+function getClient(): Anthropic | null {
+  const apiKey = process.env.ANTHROPIC_API_KEY;
+  if (!apiKey) return null;
+  return new Anthropic({ apiKey });
+}
+
+function buildSystemPrompt(name: string, personalityPrompt: string): string {
+  return `You are ${name}. ${personalityPrompt}. \nReview the following tweet draft. Provide a concise opinion (2-3 sentences max) and rate it 1-5.\nFormat your response as: your opinion text, then on a new line exactly "Rating: X/5"`;
+}
+
+function parseRating(response: string): { opinion: string; rating: number } {
+  const ratingMatch = response.match(/Rating:\s*(\d)\s*\/\s*5/);
+  const rating = ratingMatch ? parseInt(ratingMatch[1], 10) : 3;
+  const clampedRating = Math.max(1, Math.min(5, rating));
+
+  // Extract opinion: everything before the Rating line
+  const ratingIndex = response.lastIndexOf('Rating:');
+  const opinion = ratingIndex !== -1 ? response.substring(0, ratingIndex).trim() : response.trim();
+
+  return { opinion, rating: clampedRating };
+}
+
+export async function reviewPostWithJudge(
+  judgeName: string,
+  judgePrompt: string,
+  postContent: string,
+): Promise<{ opinion: string; rating: number }> {
+  const client = getClient();
+  if (!client) {
+    return {
+      opinion: 'AI service not configured -- set ANTHROPIC_API_KEY',
+      rating: 3,
+    };
+  }
+
+  const systemPrompt = buildSystemPrompt(judgeName, judgePrompt);
+
+  const response = await client.messages.create({
+    model: 'claude-sonnet-4-20250514',
+    max_tokens: 300,
+    system: systemPrompt,
+    messages: [{ role: 'user', content: postContent }],
+  });
+
+  const block = response.content[0];
+  if (block.type !== 'text') {
+    throw new Error('Unexpected response format from Claude API');
+  }
+
+  return parseRating(block.text.trim());
+}

--- a/web/src/components/AppHeader.tsx
+++ b/web/src/components/AppHeader.tsx
@@ -39,6 +39,11 @@ export default function AppHeader() {
               <Button color="inherit" component={Link} to="/users">
                 Users
               </Button>
+              {user.isAdmin && (
+                <Button color="inherit" component={Link} to="/judges">
+                  Judges
+                </Button>
+              )}
             </Box>
             <Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
               <Typography variant="body2">{user.email}</Typography>

--- a/web/src/components/PostCard.tsx
+++ b/web/src/components/PostCard.tsx
@@ -15,6 +15,7 @@ import Alert from '@mui/material/Alert';
 import CircularProgress from '@mui/material/CircularProgress';
 import type { Post, PostStatus } from '../hooks/usePosts';
 import { useUpdatePost, useTweakPost, useAcceptTweak } from '../hooks/usePosts';
+import { usePostReviews, useRequestReview, type PostReview } from '../hooks/useJudges';
 
 const statusColors: Record<PostStatus, 'default' | 'info' | 'success' | 'error'> = {
   draft: 'default',
@@ -50,6 +51,9 @@ export default function PostCard({ post }: PostCardProps) {
   const updatePost = useUpdatePost();
   const tweakPost = useTweakPost();
   const acceptTweak = useAcceptTweak();
+  const { data: reviews } = usePostReviews(post.id);
+  const requestReview = useRequestReview();
+  const [showReviews, setShowReviews] = useState(false);
 
   useEffect(() => {
     if (conversationEndRef.current) {
@@ -246,6 +250,18 @@ export default function PostCard({ post }: PostCardProps) {
                 </Button>
                 <Button
                   size="small"
+                  variant="outlined"
+                  onClick={() => {
+                    requestReview.mutate(post.id, {
+                      onSuccess: () => setShowReviews(true),
+                    });
+                  }}
+                  disabled={requestReview.isPending}
+                >
+                  {requestReview.isPending ? <CircularProgress size={16} /> : 'Ask Judges'}
+                </Button>
+                <Button
+                  size="small"
                   variant="contained"
                   onClick={handleSchedule}
                   disabled={updatePost.isPending}
@@ -275,6 +291,41 @@ export default function PostCard({ post }: PostCardProps) {
           </Box>
         </Box>
       </CardContent>
+
+      {/* Reviews Section */}
+      {reviews && reviews.length > 0 && (
+        <CardContent sx={{ pt: 0 }}>
+          <Button
+            size="small"
+            onClick={() => setShowReviews(!showReviews)}
+            sx={{ mb: 1 }}
+          >
+            {showReviews ? 'Hide Reviews' : `Show Reviews (${reviews.length})`}
+          </Button>
+          {showReviews && (
+            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
+              {reviews.map((review: PostReview) => (
+                <Box
+                  key={review.id}
+                  sx={{
+                    p: 1.5,
+                    borderRadius: 1,
+                    bgcolor: 'action.hover',
+                  }}
+                >
+                  <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 0.5 }}>
+                    <Typography variant="subtitle2">{review.judge.name}</Typography>
+                    <Rating value={review.rating} readOnly size="small" />
+                  </Box>
+                  <Typography variant="body2" sx={{ whiteSpace: 'pre-wrap' }}>
+                    {review.opinion}
+                  </Typography>
+                </Box>
+              ))}
+            </Box>
+          )}
+        </CardContent>
+      )}
 
       {/* Tweak Dialog */}
       <Dialog open={tweakOpen} onClose={handleCloseTweak} maxWidth="sm" fullWidth>

--- a/web/src/hooks/useJudges.ts
+++ b/web/src/hooks/useJudges.ts
@@ -1,0 +1,165 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { apiClient } from '../lib/apiClient';
+import { queryKeys } from '../lib/queryKeys';
+
+export type Judge = {
+  id: string;
+  name: string;
+  prompt: string;
+  createdAt: string;
+};
+
+export type BotJudge = {
+  id: string;
+  botId: string;
+  judgeId: string;
+  createdAt: string;
+  judge: Judge;
+};
+
+export type PostReview = {
+  id: string;
+  postId: string;
+  judgeId: string;
+  rating: number;
+  opinion: string;
+  createdAt: string;
+  judge: Judge;
+};
+
+type JudgeListResponse = {
+  data: Judge[];
+};
+
+type BotJudgeListResponse = {
+  data: BotJudge[];
+};
+
+type PostReviewListResponse = {
+  data: PostReview[];
+};
+
+// Judge CRUD
+export function useJudges() {
+  return useQuery({
+    queryKey: queryKeys.judges.list,
+    queryFn: async () => {
+      const response = await apiClient.get<JudgeListResponse>('/judges');
+      return response.data.data;
+    },
+  });
+}
+
+export function useCreateJudge() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (input: { name: string; prompt: string }) => {
+      const response = await apiClient.post<{ data: Judge }>('/judges', input);
+      return response.data.data;
+    },
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: queryKeys.judges.list });
+    },
+  });
+}
+
+export function useUpdateJudge() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({ id, ...input }: { id: string; name?: string; prompt?: string }) => {
+      const response = await apiClient.patch<{ data: Judge }>(`/judges/${id}`, input);
+      return response.data.data;
+    },
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: queryKeys.judges.list });
+    },
+  });
+}
+
+export function useDeleteJudge() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (id: string) => {
+      await apiClient.delete(`/judges/${id}`);
+    },
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: queryKeys.judges.list });
+    },
+  });
+}
+
+// Bot-Judge assignment
+export function useBotJudges(botId: string | undefined) {
+  return useQuery({
+    queryKey: queryKeys.bots.judges(botId ?? ''),
+    queryFn: async () => {
+      const response = await apiClient.get<BotJudgeListResponse>(`/bots/${botId}/judges`);
+      return response.data.data;
+    },
+    enabled: !!botId,
+  });
+}
+
+export function useAssignJudge() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({ botId, judgeId }: { botId: string; judgeId: string }) => {
+      const response = await apiClient.post<{ data: BotJudge }>(`/bots/${botId}/judges`, {
+        judgeId,
+      });
+      return response.data.data;
+    },
+    onSuccess: (_data, variables) => {
+      void queryClient.invalidateQueries({
+        queryKey: queryKeys.bots.judges(variables.botId),
+      });
+    },
+  });
+}
+
+export function useRemoveJudge() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({ botId, judgeId }: { botId: string; judgeId: string }) => {
+      await apiClient.delete(`/bots/${botId}/judges/${judgeId}`);
+    },
+    onSuccess: (_data, variables) => {
+      void queryClient.invalidateQueries({
+        queryKey: queryKeys.bots.judges(variables.botId),
+      });
+    },
+  });
+}
+
+// Post reviews
+export function usePostReviews(postId: string | undefined) {
+  return useQuery({
+    queryKey: queryKeys.posts.reviews(postId ?? ''),
+    queryFn: async () => {
+      const response = await apiClient.get<PostReviewListResponse>(`/posts/${postId}/reviews`);
+      return response.data.data;
+    },
+    enabled: !!postId,
+  });
+}
+
+export function useRequestReview() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (postId: string) => {
+      const response = await apiClient.post<PostReviewListResponse>(`/posts/${postId}/review`);
+      return response.data.data;
+    },
+    onSuccess: (_data, postId) => {
+      void queryClient.invalidateQueries({
+        queryKey: queryKeys.posts.reviews(postId),
+      });
+    },
+  });
+}

--- a/web/src/lib/queryKeys.ts
+++ b/web/src/lib/queryKeys.ts
@@ -7,16 +7,21 @@ export const queryKeys = {
     detail: (id: string) => ['bots', 'detail', id] as const,
     shares: (botId: string) => ['bots', 'shares', botId] as const,
     tips: (botId: string) => ['bots', 'tips', botId] as const,
+    judges: (botId: string) => ['bots', 'judges', botId] as const,
   },
   posts: {
     list: (status?: string, page?: number, showAll?: boolean) =>
       ['posts', 'list', status ?? 'all', page ?? 1, showAll ?? false] as const,
     all: ['posts'] as const,
+    reviews: (postId: string) => ['posts', 'reviews', postId] as const,
   },
   stats: {
     forBot: (botId: string) => ['stats', 'bot', botId] as const,
   },
   jobs: {
     stats: (showAll?: boolean) => ['jobs', 'stats', showAll ?? false] as const,
+  },
+  judges: {
+    list: ['judges', 'list'] as const,
   },
 } as const;

--- a/web/src/pages/DashboardPage.tsx
+++ b/web/src/pages/DashboardPage.tsx
@@ -43,6 +43,12 @@ import {
   useUpdateTip,
   useDeleteTip,
 } from '../hooks/useBot';
+import {
+  useJudges,
+  useBotJudges,
+  useAssignJudge,
+  useRemoveJudge,
+} from '../hooks/useJudges';
 import { useAuth } from '../hooks/useAuth';
 import { useStats } from '../hooks/useStats';
 import { usePosts, type PostStatus } from '../hooks/usePosts';
@@ -109,6 +115,11 @@ export default function DashboardPage() {
   const [editingTipId, setEditingTipId] = useState<string | null>(null);
   const [editingTipContent, setEditingTipContent] = useState('');
   const [deleteConfirmTipId, setDeleteConfirmTipId] = useState<string | null>(null);
+
+  const { data: allJudges } = useJudges();
+  const { data: botJudges } = useBotJudges(bot?.id);
+  const assignJudge = useAssignJudge();
+  const removeJudge = useRemoveJudge();
 
   const { data: stats, isLoading: statsLoading } = useStats(bot?.id);
   const { data: recentPostsData, isLoading: recentPostsLoading } = usePosts(undefined, 1, 5);
@@ -567,6 +578,89 @@ export default function DashboardPage() {
             </Button>
           </DialogActions>
         </Dialog>
+
+        {/* Judges Section */}
+        <Typography variant="h6" gutterBottom>
+          Judges {botJudges && `(${botJudges.length}/5)`}
+        </Typography>
+        <Card sx={{ mb: 3 }}>
+          <CardContent>
+            {botJudges && botJudges.length > 0 ? (
+              <List dense disablePadding>
+                {botJudges.map((bj, index) => (
+                  <div key={bj.id}>
+                    {index > 0 && <Divider />}
+                    <ListItem
+                      secondaryAction={
+                        <IconButton
+                          edge="end"
+                          size="small"
+                          onClick={() => {
+                            if (!bot) return;
+                            removeJudge.mutate(
+                              { botId: bot.id, judgeId: bj.judgeId },
+                              {
+                                onSuccess: () =>
+                                  showSnackbar(`Removed judge "${bj.judge.name}"`, 'success'),
+                                onError: () =>
+                                  showSnackbar('Failed to remove judge', 'error'),
+                              },
+                            );
+                          }}
+                          disabled={removeJudge.isPending}
+                        >
+                          <DeleteIcon fontSize="small" />
+                        </IconButton>
+                      }
+                    >
+                      <ListItemText
+                        primary={bj.judge.name}
+                        secondary={bj.judge.prompt.length > 100 ? bj.judge.prompt.substring(0, 100) + '...' : bj.judge.prompt}
+                      />
+                    </ListItem>
+                  </div>
+                ))}
+              </List>
+            ) : (
+              <Typography variant="body2" color="text.secondary">
+                No judges assigned. Assign judges to get AI-powered reviews on your posts.
+              </Typography>
+            )}
+            {allJudges && botJudges && botJudges.length < 5 && (
+              <Box sx={{ mt: 2 }}>
+                <Select
+                  size="small"
+                  displayEmpty
+                  value=""
+                  onChange={(e) => {
+                    const judgeId = e.target.value as string;
+                    if (!judgeId || !bot) return;
+                    assignJudge.mutate(
+                      { botId: bot.id, judgeId },
+                      {
+                        onSuccess: () => showSnackbar('Judge assigned', 'success'),
+                        onError: () => showSnackbar('Failed to assign judge', 'error'),
+                      },
+                    );
+                  }}
+                  sx={{ minWidth: 200 }}
+                  disabled={assignJudge.isPending}
+                >
+                  <MenuItem value="" disabled>
+                    Add a judge...
+                  </MenuItem>
+                  {allJudges
+                    .filter((j) => !botJudges.some((bj) => bj.judgeId === j.id))
+                    .map((j) => (
+                      <MenuItem key={j.id} value={j.id}>
+                        {j.name}
+                      </MenuItem>
+                    ))}
+                </Select>
+              </Box>
+            )}
+          </CardContent>
+        </Card>
 
         {/* Quick Actions */}
         <Typography variant="h6" gutterBottom>

--- a/web/src/pages/JudgesPage.tsx
+++ b/web/src/pages/JudgesPage.tsx
@@ -1,0 +1,317 @@
+import { useState } from 'react';
+import Box from '@mui/material/Box';
+import Container from '@mui/material/Container';
+import Typography from '@mui/material/Typography';
+import Table from '@mui/material/Table';
+import TableBody from '@mui/material/TableBody';
+import TableCell from '@mui/material/TableCell';
+import TableContainer from '@mui/material/TableContainer';
+import TableHead from '@mui/material/TableHead';
+import TableRow from '@mui/material/TableRow';
+import Paper from '@mui/material/Paper';
+import Button from '@mui/material/Button';
+import Dialog from '@mui/material/Dialog';
+import DialogTitle from '@mui/material/DialogTitle';
+import DialogContent from '@mui/material/DialogContent';
+import DialogContentText from '@mui/material/DialogContentText';
+import DialogActions from '@mui/material/DialogActions';
+import TextField from '@mui/material/TextField';
+import Snackbar from '@mui/material/Snackbar';
+import Alert from '@mui/material/Alert';
+import CircularProgress from '@mui/material/CircularProgress';
+import IconButton from '@mui/material/IconButton';
+import EditIcon from '@mui/icons-material/Edit';
+import DeleteIcon from '@mui/icons-material/Delete';
+import AppHeader from '../components/AppHeader';
+import { useJudges, useCreateJudge, useUpdateJudge, useDeleteJudge } from '../hooks/useJudges';
+import { useAuth } from '../hooks/useAuth';
+import { AxiosError } from 'axios';
+
+export default function JudgesPage() {
+  const { user } = useAuth();
+  const isAdmin = user?.isAdmin ?? false;
+
+  const { data: judges, isLoading, error } = useJudges();
+
+  const [formOpen, setFormOpen] = useState(false);
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [name, setName] = useState('');
+  const [prompt, setPrompt] = useState('');
+
+  const [deleteConfirmOpen, setDeleteConfirmOpen] = useState(false);
+  const [judgeToDelete, setJudgeToDelete] = useState<{ id: string; name: string } | null>(null);
+
+  const [snackbar, setSnackbar] = useState<{
+    open: boolean;
+    message: string;
+    severity: 'success' | 'error';
+  }>({ open: false, message: '', severity: 'success' });
+
+  const createJudge = useCreateJudge();
+  const updateJudge = useUpdateJudge();
+  const deleteJudge = useDeleteJudge();
+
+  const handleOpenCreate = () => {
+    setEditingId(null);
+    setName('');
+    setPrompt('');
+    setFormOpen(true);
+  };
+
+  const handleOpenEdit = (judge: { id: string; name: string; prompt: string }) => {
+    setEditingId(judge.id);
+    setName(judge.name);
+    setPrompt(judge.prompt);
+    setFormOpen(true);
+  };
+
+  const handleCloseForm = () => {
+    setFormOpen(false);
+    setEditingId(null);
+    setName('');
+    setPrompt('');
+  };
+
+  const handleSave = () => {
+    if (editingId) {
+      updateJudge.mutate(
+        { id: editingId, name, prompt },
+        {
+          onSuccess: () => {
+            setSnackbar({ open: true, message: 'Judge updated', severity: 'success' });
+            handleCloseForm();
+          },
+          onError: (err) => {
+            let message = 'Failed to update judge';
+            if (err instanceof AxiosError && err.response?.data?.error) {
+              message = err.response.data.error;
+            }
+            setSnackbar({ open: true, message, severity: 'error' });
+          },
+        },
+      );
+    } else {
+      createJudge.mutate(
+        { name, prompt },
+        {
+          onSuccess: () => {
+            setSnackbar({ open: true, message: 'Judge created', severity: 'success' });
+            handleCloseForm();
+          },
+          onError: (err) => {
+            let message = 'Failed to create judge';
+            if (err instanceof AxiosError && err.response?.data?.error) {
+              message = err.response.data.error;
+            }
+            setSnackbar({ open: true, message, severity: 'error' });
+          },
+        },
+      );
+    }
+  };
+
+  const handleDeleteClick = (judge: { id: string; name: string }) => {
+    setJudgeToDelete(judge);
+    setDeleteConfirmOpen(true);
+  };
+
+  const handleDeleteConfirm = () => {
+    if (!judgeToDelete) return;
+    deleteJudge.mutate(judgeToDelete.id, {
+      onSuccess: () => {
+        setSnackbar({
+          open: true,
+          message: `Judge "${judgeToDelete.name}" deleted`,
+          severity: 'success',
+        });
+        setDeleteConfirmOpen(false);
+        setJudgeToDelete(null);
+      },
+      onError: (err) => {
+        let message = 'Failed to delete judge';
+        if (err instanceof AxiosError && err.response?.data?.error) {
+          message = err.response.data.error;
+        }
+        setSnackbar({ open: true, message, severity: 'error' });
+        setDeleteConfirmOpen(false);
+        setJudgeToDelete(null);
+      },
+    });
+  };
+
+  if (!isAdmin) {
+    return (
+      <Box>
+        <AppHeader />
+        <Container maxWidth="lg" sx={{ mt: 4 }}>
+          <Alert severity="error">Admin access required</Alert>
+        </Container>
+      </Box>
+    );
+  }
+
+  return (
+    <Box>
+      <AppHeader />
+      <Container maxWidth="lg" sx={{ mt: 4 }}>
+        <Box
+          sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', mb: 3 }}
+        >
+          <Typography variant="h4" component="h1" fontWeight={700}>
+            Judges
+          </Typography>
+          <Button variant="contained" onClick={handleOpenCreate}>
+            Add Judge
+          </Button>
+        </Box>
+
+        {isLoading && (
+          <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>
+            <CircularProgress />
+          </Box>
+        )}
+
+        {error && (
+          <Alert severity="error" sx={{ mb: 2 }}>
+            Failed to load judges
+          </Alert>
+        )}
+
+        {judges && (
+          <TableContainer component={Paper}>
+            <Table>
+              <TableHead>
+                <TableRow>
+                  <TableCell>Name</TableCell>
+                  <TableCell>Personality Prompt</TableCell>
+                  <TableCell>Created At</TableCell>
+                  <TableCell align="right">Actions</TableCell>
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                {judges.map((judge) => (
+                  <TableRow key={judge.id}>
+                    <TableCell>{judge.name}</TableCell>
+                    <TableCell
+                      sx={{
+                        maxWidth: 400,
+                        overflow: 'hidden',
+                        textOverflow: 'ellipsis',
+                        whiteSpace: 'nowrap',
+                      }}
+                    >
+                      {judge.prompt}
+                    </TableCell>
+                    <TableCell>{new Date(judge.createdAt).toLocaleDateString()}</TableCell>
+                    <TableCell align="right">
+                      <Box sx={{ display: 'flex', gap: 0.5, justifyContent: 'flex-end' }}>
+                        <IconButton
+                          size="small"
+                          onClick={() => handleOpenEdit(judge)}
+                        >
+                          <EditIcon fontSize="small" />
+                        </IconButton>
+                        <IconButton
+                          size="small"
+                          color="error"
+                          onClick={() => handleDeleteClick(judge)}
+                        >
+                          <DeleteIcon fontSize="small" />
+                        </IconButton>
+                      </Box>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </TableContainer>
+        )}
+
+        {/* Create/Edit Dialog */}
+        <Dialog open={formOpen} onClose={handleCloseForm} maxWidth="sm" fullWidth>
+          <DialogTitle>{editingId ? 'Edit Judge' : 'Add Judge'}</DialogTitle>
+          <DialogContent>
+            <TextField
+              label="Name"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              fullWidth
+              sx={{ mt: 1, mb: 2 }}
+              autoFocus
+            />
+            <TextField
+              label="Personality Prompt"
+              value={prompt}
+              onChange={(e) => setPrompt(e.target.value)}
+              fullWidth
+              multiline
+              minRows={3}
+            />
+          </DialogContent>
+          <DialogActions>
+            <Button onClick={handleCloseForm}>Cancel</Button>
+            <Button
+              onClick={handleSave}
+              variant="contained"
+              disabled={
+                !name.trim() ||
+                !prompt.trim() ||
+                createJudge.isPending ||
+                updateJudge.isPending
+              }
+            >
+              {createJudge.isPending || updateJudge.isPending ? 'Saving...' : 'Save'}
+            </Button>
+          </DialogActions>
+        </Dialog>
+
+        {/* Delete Confirmation Dialog */}
+        <Dialog
+          open={deleteConfirmOpen}
+          onClose={() => {
+            setDeleteConfirmOpen(false);
+            setJudgeToDelete(null);
+          }}
+        >
+          <DialogTitle>Delete Judge</DialogTitle>
+          <DialogContent>
+            <DialogContentText>
+              Are you sure you want to delete the judge &quot;{judgeToDelete?.name}&quot;?
+            </DialogContentText>
+          </DialogContent>
+          <DialogActions>
+            <Button
+              onClick={() => {
+                setDeleteConfirmOpen(false);
+                setJudgeToDelete(null);
+              }}
+            >
+              Cancel
+            </Button>
+            <Button
+              onClick={handleDeleteConfirm}
+              color="error"
+              variant="contained"
+              disabled={deleteJudge.isPending}
+            >
+              {deleteJudge.isPending ? 'Deleting...' : 'Delete'}
+            </Button>
+          </DialogActions>
+        </Dialog>
+
+        <Snackbar
+          open={snackbar.open}
+          autoHideDuration={4000}
+          onClose={() => setSnackbar((s) => ({ ...s, open: false }))}
+        >
+          <Alert
+            severity={snackbar.severity}
+            onClose={() => setSnackbar((s) => ({ ...s, open: false }))}
+          >
+            {snackbar.message}
+          </Alert>
+        </Snackbar>
+      </Container>
+    </Box>
+  );
+}

--- a/web/src/routes/router.tsx
+++ b/web/src/routes/router.tsx
@@ -12,6 +12,7 @@ import DashboardPage from '../pages/DashboardPage';
 import PostsPage from '../pages/PostsPage';
 import UsersPage from '../pages/UsersPage';
 import JobQueuePage from '../pages/JobQueuePage';
+import JudgesPage from '../pages/JudgesPage';
 
 async function checkAuth(): Promise<boolean> {
   try {
@@ -80,6 +81,18 @@ const usersRoute = createRoute({
   component: UsersPage,
 });
 
+const judgesRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: '/judges',
+  beforeLoad: async () => {
+    const authenticated = await checkAuth();
+    if (!authenticated) {
+      throw redirect({ to: '/login' });
+    }
+  },
+  component: JudgesPage,
+});
+
 const indexRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: '/',
@@ -100,6 +113,7 @@ const routeTree = rootRoute.addChildren([
   postsRoute,
   jobsRoute,
   usersRoute,
+  judgesRoute,
 ]);
 
 export function createAppRouter(_queryClient?: QueryClient) {


### PR DESCRIPTION
## Summary
Implements #54 — AI "judges" with distinct personalities that review draft posts.

- **Judge model**: name + personality prompt, 6 default judges seeded via migration
- **Admin management**: `/judges` page for CRUD (create/edit/delete judges)
- **Bot-judge assignment**: assign up to 5 judges per bot on the dashboard
- **Post review**: "Ask Judges" button on draft posts — calls all assigned judges in parallel, each returns a concise opinion + 1-5 rating
- **Review display**: collapsible reviews section on PostCard with judge name, opinion, and star rating

### Seeded Judges
1. Junior Engineer (worried about career in AI world)
2. Senior Engineer (skeptical of AI)
3. Non-Technical CTO (management/strategy perspective)
4. Technical CTO (overwhelmed, values practicality)
5. Skeptical Investor (unclear on tech ROI)
6. Talent-Focused Investor (startup growth through talent)

## Test plan
- [ ] Verify 6 judges exist after migration
- [ ] Admin can create/edit/delete judges on `/judges`
- [ ] Non-admin sees "Admin access required" on `/judges`
- [ ] Assign up to 5 judges to a bot on dashboard; verify 6th is rejected
- [ ] Click "Ask Judges" on a draft post, verify reviews appear with opinions + ratings
- [ ] Toggle "Show/Hide Reviews" works correctly
- [ ] Removing a judge from bot doesn't delete past reviews

Closes #54

🤖 Generated with [Claude Code](https://claude.com/claude-code)