### PR TITLE
feat: add platform type to bots (X default, others coming soon)

### DIFF
--- a/api/prisma/migrations/20260314050000_add_bot_platform/migration.sql
+++ b/api/prisma/migrations/20260314050000_add_bot_platform/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Bot" ADD COLUMN "platform" TEXT NOT NULL DEFAULT 'x';

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -26,6 +26,7 @@ model Bot {
   xAccessToken        String   @default("")
   xAccessSecret       String   @default("")
   xAccountHandle      String   @default("")
+  platform            String   @default("x")
   prompt              String   @db.Text
   postMode            String   @default("manual")
   postsPerDay         Int      @default(3)

--- a/api/src/controllers/botController.ts
+++ b/api/src/controllers/botController.ts
@@ -7,6 +7,7 @@ import { botTipRepository } from '../repositories/botTipRepository.js';
 import { paginationSchema, uuidSchema } from '../utils/validation.js';
 
 const createBotSchema = z.object({
+  platform: z.enum(['x']).default('x'),
   prompt: z.string().min(1, 'Prompt is required'),
   postMode: z.enum(['auto', 'manual']).default('manual'),
   postsPerDay: z.number().int().min(1).max(15).default(3),

--- a/api/src/repositories/botRepository.ts
+++ b/api/src/repositories/botRepository.ts
@@ -25,6 +25,7 @@ type UpdateBotInput = Partial<
 const botSelect = {
   id: true,
   userId: true,
+  platform: true,
   xAccountHandle: true,
   prompt: true,
   postMode: true,

--- a/api/src/services/botService.ts
+++ b/api/src/services/botService.ts
@@ -7,6 +7,7 @@ import { NotFoundError, ForbiddenError } from '../utils/errors.js';
 
 type CreateBotInput = {
   userId: string;
+  platform?: string;
   prompt: string;
   postMode: string;
   postsPerDay: number;
@@ -39,6 +40,7 @@ export const botService = {
         select: {
           id: true,
           userId: true,
+          platform: true,
           xAccountHandle: true,
           prompt: true,
           postMode: true,

--- a/web/src/components/BotSetupForm.tsx
+++ b/web/src/components/BotSetupForm.tsx
@@ -12,10 +12,18 @@ import Slider from '@mui/material/Slider';
 import TextField from '@mui/material/TextField';
 import Typography from '@mui/material/Typography';
 import Alert from '@mui/material/Alert';
+import Chip from '@mui/material/Chip';
 import InputLabel from '@mui/material/InputLabel';
 import { z } from 'zod';
 
+const PLATFORMS = [
+  { value: 'x', label: 'X (Twitter)', enabled: true },
+  { value: 'linkedin', label: 'LinkedIn', enabled: false },
+  { value: 'threads', label: 'Threads', enabled: false },
+] as const;
+
 const botConfigSchema = z.object({
+  platform: z.enum(['x']),
   prompt: z.string().min(1, 'Prompt is required'),
   postMode: z.enum(['auto', 'manual']),
   postsPerDay: z.number().int().min(1).max(15),
@@ -34,6 +42,7 @@ type BotSetupFormProps = {
 };
 
 const defaultValues: BotConfigValues = {
+  platform: 'x',
   prompt: '',
   postMode: 'manual',
   postsPerDay: 3,
@@ -78,6 +87,23 @@ export default function BotSetupForm({
       onSubmit={handleSubmit}
       sx={{ display: 'flex', flexDirection: 'column', gap: 3 }}
     >
+      <FormControl>
+        <FormLabel>Platform</FormLabel>
+        <Box sx={{ display: 'flex', gap: 1, mt: 1 }}>
+          {PLATFORMS.map((p) => (
+            <Chip
+              key={p.value}
+              label={p.enabled ? p.label : `${p.label} (coming soon)`}
+              color={values.platform === p.value ? 'primary' : 'default'}
+              variant={values.platform === p.value ? 'filled' : 'outlined'}
+              onClick={p.enabled ? () => setValues((v) => ({ ...v, platform: p.value as 'x' })) : undefined}
+              disabled={!p.enabled}
+              sx={{ opacity: p.enabled ? 1 : 0.5 }}
+            />
+          ))}
+        </Box>
+      </FormControl>
+
       <TextField
         label="Bot Prompt"
         multiline

--- a/web/src/hooks/useBot.ts
+++ b/web/src/hooks/useBot.ts
@@ -11,6 +11,7 @@ type BotOwner = {
 export type Bot = {
   id: string;
   userId: string;
+  platform: string;
   xAccountHandle: string;
   prompt: string;
   postMode: string;

--- a/web/src/pages/DashboardPage.tsx
+++ b/web/src/pages/DashboardPage.tsx
@@ -288,6 +288,11 @@ export default function DashboardPage() {
                 <Typography variant="h5">@{bot.xAccountHandle || 'Not connected'}</Typography>
                 <Box sx={{ display: 'flex', gap: 1, mt: 1 }}>
                   <Chip
+                    label={bot.platform === 'x' ? 'X (Twitter)' : bot.platform}
+                    size="small"
+                    variant="outlined"
+                  />
+                  <Chip
                     label={bot.active ? 'Active' : 'Inactive'}
                     color={bot.active ? 'success' : 'default'}
                     size="small"


### PR DESCRIPTION
## Summary
- Add `platform` field to Bot model (default: `x`)
- Platform selector in bot setup form showing X (Twitter) as enabled, LinkedIn and Threads as "coming soon" chips
- Platform chip displayed on bot dashboard
- API validates platform on create (only `x` accepted currently)

## Test plan
- [ ] Create a new bot — verify X is pre-selected, LinkedIn/Threads shown as disabled "coming soon"
- [ ] Existing bots default to X platform
- [ ] Platform chip visible on dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)