### PR TITLE
feat: include recent posts context in generation and judge reviews

### DIFF
--- a/api/src/controllers/botController.ts
+++ b/api/src/controllers/botController.ts
@@ -108,7 +108,9 @@ export const botController = {
 
       const posts = [];
       for (let i = 0; i < count; i++) {
-        const result = await generateTweet(bot.prompt, tipContents);
+        const recentPosts = await postRepository.findRecentByBotId(bot.id, 10);
+        const recentContents = recentPosts.map((p: { content: string }) => p.content);
+        const result = await generateTweet(bot.prompt, tipContents, recentContents);
         if (result.success) {
           const post = await postRepository.create({
             botId: bot.id,

--- a/api/src/controllers/postReviewController.ts
+++ b/api/src/controllers/postReviewController.ts
@@ -1,7 +1,7 @@
 import { Request, Response, NextFunction } from 'express';
 import { z } from 'zod';
-import { postReviewRepository } from '../repositories/postReviewRepository.js';
 import { postRepository } from '../repositories/postRepository.js';
+import { postReviewRepository } from '../repositories/postReviewRepository.js';
 import { botJudgeRepository } from '../repositories/botJudgeRepository.js';
 import { botRepository } from '../repositories/botRepository.js';
 import { botShareRepository } from '../repositories/botShareRepository.js';
@@ -57,10 +57,21 @@ export const postReviewController = {
         throw new ValidationError('No judges assigned to this bot. Assign judges first.');
       }
 
+      // Fetch recent posts for repetition context
+      const recentPosts = await postRepository.findRecentByBotId(post.botId, 10);
+      const recentContents = recentPosts
+        .filter((rp: { content: string }) => rp.content !== post.content)
+        .map((rp: { content: string }) => rp.content);
+
       // Call AI for each judge in parallel
       const reviewPromises = botJudges.map(
         async (bj: { judgeId: string; judge: { name: string; prompt: string } }) => {
-          const result = await reviewPostWithJudge(bj.judge.name, bj.judge.prompt, post.content);
+          const result = await reviewPostWithJudge(
+            bj.judge.name,
+            bj.judge.prompt,
+            post.content,
+            recentContents,
+          );
           return {
             postId: id,
             judgeId: bj.judgeId,

--- a/api/src/repositories/postRepository.ts
+++ b/api/src/repositories/postRepository.ts
@@ -140,4 +140,16 @@ export const postRepository = {
       },
     });
   },
+
+  async findRecentByBotId(botId: string, limit = 10) {
+    return prisma.post.findMany({
+      where: {
+        botId,
+        status: { in: ['draft', 'scheduled', 'published'] },
+      },
+      select: { content: true },
+      orderBy: { createdAt: 'desc' },
+      take: limit,
+    });
+  },
 };

--- a/api/src/services/aiService.ts
+++ b/api/src/services/aiService.ts
@@ -74,7 +74,11 @@ async function callClaudeWithMessages(
   throw new Error('Unexpected response format from Claude API');
 }
 
-export async function generateTweet(prompt: string, tips?: string[]): Promise<GenerateTweetResult> {
+export async function generateTweet(
+  prompt: string,
+  tips?: string[],
+  recentPosts?: string[],
+): Promise<GenerateTweetResult> {
   const client = getClient();
 
   if (!client) {
@@ -88,6 +92,9 @@ export async function generateTweet(prompt: string, tips?: string[]): Promise<Ge
   let systemPrompt = SYSTEM_PROMPT;
   if (tips && tips.length > 0) {
     systemPrompt += `\n\nRemember these tips from past feedback:\n${tips.map((t) => `- ${t}`).join('\n')}`;
+  }
+  if (recentPosts && recentPosts.length > 0) {
+    systemPrompt += `\n\nHere are recent posts for this account — make sure your new tweet is fresh and different, not repetitive:\n${recentPosts.map((p) => `- ${p}`).join('\n')}`;
   }
 
   // First attempt

--- a/api/src/services/judgeAiService.ts
+++ b/api/src/services/judgeAiService.ts
@@ -7,7 +7,7 @@ function getClient(): Anthropic | null {
 }
 
 function buildSystemPrompt(name: string, personalityPrompt: string): string {
-  return `You are ${name}. ${personalityPrompt}. \nReview the following tweet draft. Provide a concise opinion (2-3 sentences max) and rate it 1-5.\nFormat your response as: your opinion text, then on a new line exactly "Rating: X/5"`;
+  return `You are ${name}. ${personalityPrompt}. \nReview the following tweet draft. Consider originality and whether it feels repetitive compared to recent posts. Provide a concise opinion (2-3 sentences max) and rate it 1-5.\nFormat your response as: your opinion text, then on a new line exactly "Rating: X/5"`;
 }
 
 function parseRating(response: string): { opinion: string; rating: number } {
@@ -26,6 +26,7 @@ export async function reviewPostWithJudge(
   judgeName: string,
   judgePrompt: string,
   postContent: string,
+  recentPosts?: string[],
 ): Promise<{ opinion: string; rating: number }> {
   const client = getClient();
   if (!client) {
@@ -41,7 +42,15 @@ export async function reviewPostWithJudge(
     model: 'claude-sonnet-4-20250514',
     max_tokens: 300,
     system: systemPrompt,
-    messages: [{ role: 'user', content: postContent }],
+    messages: [
+      {
+        role: 'user',
+        content:
+          recentPosts && recentPosts.length > 0
+            ? `Tweet to review:\n${postContent}\n\nRecent posts from this account for context (consider repetition):\n${recentPosts.map((p) => '- ' + p).join('\n')}`
+            : postContent,
+      },
+    ],
   });
 
   const block = response.content[0];

--- a/api/src/worker/jobWorker.ts
+++ b/api/src/worker/jobWorker.ts
@@ -137,9 +137,11 @@ async function processJobs(): Promise<void> {
         }
 
         const tips = await botTipRepository.findByBotId(bot.id);
+        const recentPosts = await postRepository.findRecentByBotId(bot.id, 10);
         const result = await generateTweet(
           bot.prompt,
           tips.map((t: { content: string }) => t.content),
+          recentPosts.map((p: { content: string }) => p.content),
         );
 
         if (!result.success) {


### PR DESCRIPTION
## Summary
- When generating new tweets (via job worker or practice drafts), the last 10 recent posts are included in the AI system prompt to avoid repetitive content
- When judges review a post, they also receive recent posts for context so they can evaluate originality and flag repetition
- New `findRecentByBotId` repository method fetches last 10 draft/scheduled/published posts

## Test plan
- [ ] Generate practice drafts — verify new drafts differ from recent posts
- [ ] Ask judges to review — verify opinions may reference repetition if applicable
- [ ] Job worker generates posts with recent context

🤖 Generated with [Claude Code](https://claude.com/claude-code)