### PR TITLE
feat: show git SHA and date in app header

### DIFF
--- a/web/src/components/AppHeader.tsx
+++ b/web/src/components/AppHeader.tsx
@@ -4,7 +4,11 @@ import Typography from '@mui/material/Typography';
 import Button from '@mui/material/Button';
 import Box from '@mui/material/Box';
 import { Link } from '@tanstack/react-router';
+import Tooltip from '@mui/material/Tooltip';
 import { useAuth, useLogoutMutation } from '../hooks/useAuth';
+
+declare const __GIT_SHA__: string;
+declare const __GIT_DATE__: string;
 
 export default function AppHeader() {
   const { user } = useAuth();
@@ -21,9 +25,17 @@ export default function AppHeader() {
   return (
     <AppBar position="static">
       <Toolbar>
-        <Typography variant="h6" component="div" sx={{ mr: 3 }}>
+        <Typography variant="h6" component="div" sx={{ mr: 1 }}>
           X Bot Platform
         </Typography>
+        <Tooltip title={`${__GIT_SHA__} (${__GIT_DATE__})`}>
+          <Typography
+            variant="caption"
+            sx={{ mr: 2, opacity: 0.5, cursor: 'default', userSelect: 'none' }}
+          >
+            {__GIT_SHA__}
+          </Typography>
+        </Tooltip>
         {user && (
           <>
             <Box sx={{ display: 'flex', gap: 1, flexGrow: 1 }}>

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -1,8 +1,25 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
+import { execSync } from 'child_process';
+
+function gitInfo() {
+  try {
+    const sha = execSync('git rev-parse --short HEAD').toString().trim();
+    const date = execSync('git log -1 --format=%ci').toString().trim().split(' ')[0];
+    return { sha, date };
+  } catch {
+    return { sha: 'unknown', date: 'unknown' };
+  }
+}
+
+const git = gitInfo();
 
 export default defineConfig({
   plugins: [react()],
+  define: {
+    __GIT_SHA__: JSON.stringify(git.sha),
+    __GIT_DATE__: JSON.stringify(git.date),
+  },
   server: {
     port: 3000,
     proxy: {


### PR DESCRIPTION
## Summary
- Inject git short SHA and last commit date at build time via Vite `define`
- Show SHA discreetly (50% opacity) next to the app title in the header
- Hover tooltip shows full info: `abc1234 (2026-03-14)`

## Test plan
- [ ] Verify SHA appears next to "X Bot Platform" in the header
- [ ] Verify tooltip shows SHA and date on hover
- [ ] Verify it builds correctly in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)