### PR TITLE
feat: reinstate discarded posts back to draft

### DIFF
--- a/api/src/controllers/postController.ts
+++ b/api/src/controllers/postController.ts
@@ -16,7 +16,7 @@ const postIdParamSchema = z.object({
 const updatePostSchema = z.object({
   content: z.string().min(1, 'Content must not be empty').optional(),
   rating: z.number().int().min(1).max(5).nullable().optional(),
-  status: z.enum(['scheduled', 'discarded']).optional(),
+  status: z.enum(['draft', 'scheduled', 'discarded']).optional(),
   scheduledAt: z.string().datetime().nullable().optional(),
 });
 

--- a/api/src/services/postService.ts
+++ b/api/src/services/postService.ts
@@ -7,7 +7,7 @@ import { NotFoundError, ForbiddenError, ValidationError } from '../utils/errors.
 type UpdatePostInput = {
   content?: string;
   rating?: number | null;
-  status?: 'scheduled' | 'discarded';
+  status?: 'draft' | 'scheduled' | 'discarded';
   scheduledAt?: string | null;
 };
 
@@ -44,8 +44,8 @@ export const postService = {
     if (post.status === 'published') {
       throw new ForbiddenError('Cannot modify a published post');
     }
-    if (post.status === 'discarded') {
-      throw new ForbiddenError('Cannot modify a discarded post');
+    if (post.status === 'discarded' && input.status !== 'draft') {
+      throw new ForbiddenError('Discarded posts can only be reinstated to draft');
     }
 
     // Validate content changes: only allowed on drafts
@@ -89,6 +89,9 @@ export const postService = {
       updateData.scheduledAt = input.scheduledAt ? new Date(input.scheduledAt) : new Date();
     } else if (input.status === 'discarded') {
       updateData.status = 'discarded';
+    } else if (input.status === 'draft') {
+      updateData.status = 'draft';
+      updateData.scheduledAt = null;
     }
 
     return postRepository.update(postId, updateData);
@@ -197,6 +200,8 @@ function getAllowedTransitions(currentStatus: string): string[] {
       return ['scheduled', 'discarded'];
     case 'scheduled':
       return ['discarded'];
+    case 'discarded':
+      return ['draft'];
     default:
       return [];
   }

--- a/web/src/components/PostCard.tsx
+++ b/web/src/components/PostCard.tsx
@@ -299,15 +299,25 @@ export default function PostCard({ post }: PostCardProps) {
               </Button>
             )}
             {post.status === 'discarded' && (
-              <Button
-                size="small"
-                color="error"
-                variant="outlined"
-                onClick={() => setDeleteConfirmOpen(true)}
-                disabled={deletePost.isPending}
-              >
-                {deletePost.isPending ? <CircularProgress size={16} /> : 'Delete'}
-              </Button>
+              <>
+                <Button
+                  size="small"
+                  variant="outlined"
+                  onClick={() => updatePost.mutate({ id: post.id, status: 'draft' })}
+                  disabled={updatePost.isPending}
+                >
+                  Reinstate
+                </Button>
+                <Button
+                  size="small"
+                  color="error"
+                  variant="outlined"
+                  onClick={() => setDeleteConfirmOpen(true)}
+                  disabled={deletePost.isPending}
+                >
+                  {deletePost.isPending ? <CircularProgress size={16} /> : 'Delete'}
+                </Button>
+              </>
             )}
           </Box>
         </Box>


### PR DESCRIPTION
## Summary
- Allow discarded→draft status transition
- Add "Reinstate" button on discarded post cards (next to Delete)
- Clears scheduledAt when reinstating

## Test plan
- [ ] Verify discarded posts show a "Reinstate" button
- [ ] Verify clicking Reinstate moves post back to draft status
- [ ] Verify reinstated post appears in Drafts tab with full edit/tweak capabilities

🤖 Generated with [Claude Code](https://claude.com/claude-code)