### PR TITLE
fix: reorder posts tabs — Drafts first, All last

### DIFF
--- a/web/src/pages/PostsPage.tsx
+++ b/web/src/pages/PostsPage.tsx
@@ -19,7 +19,6 @@ import CircularProgress from '@mui/material/CircularProgress';
 import { usePosts, useDeleteAllDiscarded } from '../hooks/usePosts';
 
 const TAB_CONFIG = [
-  { label: 'All', status: undefined, emptyMessage: 'No posts yet' },
   { label: 'Drafts', status: 'draft', emptyMessage: 'No drafts yet' },
   {
     label: 'Scheduled',
@@ -36,6 +35,7 @@ const TAB_CONFIG = [
     status: 'discarded',
     emptyMessage: 'No discarded posts',
   },
+  { label: 'All', status: undefined, emptyMessage: 'No posts yet' },
 ] as const;
 
 export default function PostsPage() {


### PR DESCRIPTION
## Summary
- Move Drafts tab to first position (default on page load)
- Move All tab to last position
- Tab order: Drafts, Scheduled, Published, Discarded, All

🤖 Generated with [Claude Code](https://claude.com/claude-code)