### PR TITLE
Upgrade Claude model to Sonnet 4.6

### DIFF
--- a/api/src/services/aiService.ts
+++ b/api/src/services/aiService.ts
@@ -39,7 +39,7 @@ async function callClaude(
   systemPrompt?: string,
 ): Promise<string> {
   const response = await client.messages.create({
-    model: 'claude-sonnet-4-20250514',
+    model: 'claude-sonnet-4-6-20250627',
     max_tokens: 300,
     system: systemPrompt ?? SYSTEM_PROMPT,
     messages: [{ role: 'user', content: prompt }],
@@ -60,7 +60,7 @@ async function callClaudeWithMessages(
   maxTokens = 300,
 ): Promise<string> {
   const response = await client.messages.create({
-    model: 'claude-sonnet-4-20250514',
+    model: 'claude-sonnet-4-6-20250627',
     max_tokens: maxTokens,
     system: systemPrompt,
     messages,

--- a/api/src/services/judgeAiService.ts
+++ b/api/src/services/judgeAiService.ts
@@ -39,7 +39,7 @@ export async function reviewPostWithJudge(
   const systemPrompt = buildSystemPrompt(judgeName, judgePrompt);
 
   const response = await client.messages.create({
-    model: 'claude-sonnet-4-20250514',
+    model: 'claude-sonnet-4-6-20250627',
     max_tokens: 300,
     system: systemPrompt,
     messages: [


### PR DESCRIPTION
## Summary
- Update Anthropic API model from `claude-sonnet-4-20250514` to `claude-sonnet-4-6-20250627` across all 3 call sites
- Affects tweet generation, tweet tweaking, and judge reviews

## Test plan
- [ ] CI passes
- [ ] Verify tweet generation works with new model
- [ ] Verify judge reviews return expected format

🤖 Generated with [Claude Code](https://claude.com/claude-code)