### PR TITLE
Fix Render deploy: add datasource url for migrate deploy

### DIFF
--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -5,6 +5,7 @@ generator client {
 
 datasource db {
   provider = "postgresql"
+  url      = env("DATABASE_URL")
 }
 
 model User {


### PR DESCRIPTION
## Summary
- Add `url = env("DATABASE_URL")` back to the Prisma datasource block
- `prisma migrate deploy` requires the URL in the schema at runtime, even when using driver adapters
- Fixes Render deployment failure after Prisma 7 upgrade

## Test plan
- [ ] CI passes
- [ ] Render deployment succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)