### PR TITLE
Fix Render deploy: add type module for Prisma 7 ESM

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -2,6 +2,7 @@
   "name": "@x-bot/api",
   "version": "0.1.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "build": "tsc",
     "dev": "nodemon --exec tsx src/index.ts",


### PR DESCRIPTION
## Summary
- Add `"type": "module"` to `api/package.json`
- Prisma 7 generates ESM-only code; without this, Node.js treats compiled output as CJS causing `exports is not defined` at runtime
- Fixes Render deployment crash after Prisma 7 upgrade

## Test plan
- [ ] CI passes (typecheck, lint, build, E2E)
- [ ] Render deployment starts successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)