### PR TITLE
Add style prompts to bots for varied post generation

### DIFF
--- a/api/prisma/migrations/20260315000000_add_bot_styles/migration.sql
+++ b/api/prisma/migrations/20260315000000_add_bot_styles/migration.sql
@@ -1,0 +1,15 @@
+-- CreateTable
+CREATE TABLE "BotStyle" (
+    "id" UUID NOT NULL DEFAULT gen_random_uuid(),
+    "botId" UUID NOT NULL,
+    "content" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "BotStyle_pkey" PRIMARY KEY ("id")
+);
+
+-- AddColumn
+ALTER TABLE "Post" ADD COLUMN "stylePrompt" TEXT;
+
+-- AddForeignKey
+ALTER TABLE "BotStyle" ADD CONSTRAINT "BotStyle_botId_fkey" FOREIGN KEY ("botId") REFERENCES "Bot"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -41,6 +41,7 @@ model Bot {
   jobs      Job[]
   shares    BotShare[]
   tips      BotTip[]
+  styles    BotStyle[]
   botJudges BotJudge[]
 }
 
@@ -67,6 +68,8 @@ model Post {
   publishedAt DateTime?
   createdAt   DateTime  @default(now())
 
+  stylePrompt String?  @db.Text
+
   bot     Bot          @relation(fields: [botId], references: [id])
   job     Job?         @relation(fields: [jobId], references: [id])
   reviews PostReview[]
@@ -76,6 +79,15 @@ model Post {
 }
 
 model BotTip {
+  id        String   @id @default(uuid()) @db.Uuid
+  botId     String   @db.Uuid
+  content   String   @db.Text
+  createdAt DateTime @default(now())
+
+  bot Bot @relation(fields: [botId], references: [id])
+}
+
+model BotStyle {
   id        String   @id @default(uuid()) @db.Uuid
   botId     String   @db.Uuid
   content   String   @db.Text

--- a/api/src/controllers/botController.ts
+++ b/api/src/controllers/botController.ts
@@ -4,6 +4,7 @@ import { botService } from '../services/botService.js';
 import { generateTweet } from '../services/aiService.js';
 import { postRepository } from '../repositories/postRepository.js';
 import { botTipRepository } from '../repositories/botTipRepository.js';
+import { botStyleRepository } from '../repositories/botStyleRepository.js';
 import { paginationSchema, uuidSchema } from '../utils/validation.js';
 
 const createBotSchema = z.object({
@@ -105,17 +106,26 @@ export const botController = {
 
       const tips = await botTipRepository.findByBotId(bot.id);
       const tipContents = tips.map((t: { content: string }) => t.content);
+      const styles = await botStyleRepository.findByBotId(bot.id);
 
       const posts = [];
       for (let i = 0; i < count; i++) {
         const recentPosts = await postRepository.findRecentByBotId(bot.id, 10);
         const recentContents = recentPosts.map((p: { content: string }) => p.content);
-        const result = await generateTweet(bot.prompt, tipContents, recentContents);
+        const selectedStyle =
+          styles.length > 0 ? styles[Math.floor(Math.random() * styles.length)] : null;
+        const result = await generateTweet(
+          bot.prompt,
+          tipContents,
+          recentContents,
+          selectedStyle?.content,
+        );
         if (result.success) {
           const post = await postRepository.create({
             botId: bot.id,
             content: result.content,
             status: 'draft',
+            stylePrompt: selectedStyle?.content ?? null,
           });
           posts.push(post);
         }

--- a/api/src/controllers/botStyleController.ts
+++ b/api/src/controllers/botStyleController.ts
@@ -1,0 +1,79 @@
+import { Request, Response, NextFunction } from 'express';
+import { z } from 'zod';
+import { botStyleService } from '../services/botStyleService.js';
+import { uuidSchema } from '../utils/validation.js';
+
+const botIdParamSchema = z.object({
+  id: uuidSchema,
+});
+
+const styleIdParamSchema = z.object({
+  id: uuidSchema,
+  styleId: uuidSchema,
+});
+
+const createStyleSchema = z.object({
+  content: z.string().min(1, 'Content must not be empty'),
+});
+
+const updateStyleSchema = z.object({
+  content: z.string().min(1, 'Content must not be empty'),
+});
+
+export const botStyleController = {
+  async list(req: Request, res: Response, next: NextFunction): Promise<void> {
+    try {
+      const userId = req.userId!;
+      const { id } = botIdParamSchema.parse(req.params);
+      const styles = await botStyleService.list(id, userId);
+
+      res.status(200).json({
+        data: styles,
+      });
+    } catch (err) {
+      next(err);
+    }
+  },
+
+  async create(req: Request, res: Response, next: NextFunction): Promise<void> {
+    try {
+      const userId = req.userId!;
+      const { id } = botIdParamSchema.parse(req.params);
+      const { content } = createStyleSchema.parse(req.body);
+      const style = await botStyleService.create(id, userId, content);
+
+      res.status(201).json({
+        data: style,
+      });
+    } catch (err) {
+      next(err);
+    }
+  },
+
+  async update(req: Request, res: Response, next: NextFunction): Promise<void> {
+    try {
+      const userId = req.userId!;
+      const { id, styleId } = styleIdParamSchema.parse(req.params);
+      const { content } = updateStyleSchema.parse(req.body);
+      const style = await botStyleService.update(id, styleId, userId, content);
+
+      res.status(200).json({
+        data: style,
+      });
+    } catch (err) {
+      next(err);
+    }
+  },
+
+  async remove(req: Request, res: Response, next: NextFunction): Promise<void> {
+    try {
+      const userId = req.userId!;
+      const { id, styleId } = styleIdParamSchema.parse(req.params);
+      await botStyleService.remove(id, styleId, userId);
+
+      res.status(204).send();
+    } catch (err) {
+      next(err);
+    }
+  },
+};

--- a/api/src/repositories/botStyleRepository.ts
+++ b/api/src/repositories/botStyleRepository.ts
@@ -1,0 +1,39 @@
+import { prisma } from '../utils/prisma.js';
+
+export const botStyleRepository = {
+  async findByBotId(botId: string) {
+    return prisma.botStyle.findMany({
+      where: { botId },
+      orderBy: { createdAt: 'desc' },
+    });
+  },
+
+  async findById(id: string) {
+    return prisma.botStyle.findUnique({
+      where: { id },
+    });
+  },
+
+  async create(botId: string, content: string) {
+    return prisma.botStyle.create({
+      data: { botId, content },
+    });
+  },
+
+  async update(id: string, content: string) {
+    return prisma.botStyle.update({
+      where: { id },
+      data: { content },
+    });
+  },
+
+  async delete(id: string) {
+    return prisma.botStyle.delete({
+      where: { id },
+    });
+  },
+
+  async countByBotId(botId: string) {
+    return prisma.botStyle.count({ where: { botId } });
+  },
+};

--- a/api/src/repositories/postRepository.ts
+++ b/api/src/repositories/postRepository.ts
@@ -10,6 +10,7 @@ export const postRepository = {
     content: string;
     status: string;
     scheduledAt?: Date | null;
+    stylePrompt?: string | null;
   }) {
     return prisma.post.create({
       data: {
@@ -18,6 +19,7 @@ export const postRepository = {
         content: data.content,
         status: data.status,
         scheduledAt: data.scheduledAt ?? null,
+        stylePrompt: data.stylePrompt ?? null,
       },
     });
   },

--- a/api/src/routes/botRoutes.ts
+++ b/api/src/routes/botRoutes.ts
@@ -2,6 +2,7 @@ import { Router } from 'express';
 import { botController } from '../controllers/botController.js';
 import { botShareController } from '../controllers/botShareController.js';
 import { botTipController } from '../controllers/botTipController.js';
+import { botStyleController } from '../controllers/botStyleController.js';
 import { botJudgeController } from '../controllers/botJudgeController.js';
 import { authMiddleware } from '../middleware/auth.js';
 
@@ -27,6 +28,12 @@ router.delete('/:id/shares/:userId', botShareController.remove);
 router.get('/:id/tips', botTipController.list);
 router.patch('/:id/tips/:tipId', botTipController.update);
 router.delete('/:id/tips/:tipId', botTipController.remove);
+
+// Style routes
+router.get('/:id/styles', botStyleController.list);
+router.post('/:id/styles', botStyleController.create);
+router.patch('/:id/styles/:styleId', botStyleController.update);
+router.delete('/:id/styles/:styleId', botStyleController.remove);
 
 // Judge assignment routes
 router.get('/:id/judges', botJudgeController.list);

--- a/api/src/services/aiService.ts
+++ b/api/src/services/aiService.ts
@@ -78,6 +78,7 @@ export async function generateTweet(
   prompt: string,
   tips?: string[],
   recentPosts?: string[],
+  stylePrompt?: string,
 ): Promise<GenerateTweetResult> {
   const client = getClient();
 
@@ -95,6 +96,9 @@ export async function generateTweet(
   }
   if (recentPosts && recentPosts.length > 0) {
     systemPrompt += `\n\nHere are recent posts for this account — make sure your new tweet is fresh and different, not repetitive:\n${recentPosts.map((p) => `- ${p}`).join('\n')}`;
+  }
+  if (stylePrompt) {
+    systemPrompt += `\n\nWrite in this style: ${stylePrompt}`;
   }
 
   // First attempt

--- a/api/src/services/botStyleService.ts
+++ b/api/src/services/botStyleService.ts
@@ -1,0 +1,59 @@
+import { botStyleRepository } from '../repositories/botStyleRepository.js';
+import { botRepository } from '../repositories/botRepository.js';
+import { botShareRepository } from '../repositories/botShareRepository.js';
+import { NotFoundError, ForbiddenError, ValidationError } from '../utils/errors.js';
+
+const MAX_STYLES_PER_BOT = 5;
+
+async function assertBotAccess(botId: string, userId: string): Promise<void> {
+  const bot = await botRepository.findById(botId);
+  if (!bot) {
+    throw new NotFoundError('Bot not found');
+  }
+  if (bot.userId !== userId) {
+    const share = await botShareRepository.findByBotIdAndUserId(botId, userId);
+    if (!share) {
+      throw new ForbiddenError('You do not have access to this bot');
+    }
+  }
+}
+
+export const botStyleService = {
+  async list(botId: string, userId: string) {
+    await assertBotAccess(botId, userId);
+    return botStyleRepository.findByBotId(botId);
+  },
+
+  async create(botId: string, userId: string, content: string) {
+    await assertBotAccess(botId, userId);
+
+    const count = await botStyleRepository.countByBotId(botId);
+    if (count >= MAX_STYLES_PER_BOT) {
+      throw new ValidationError(`Maximum of ${MAX_STYLES_PER_BOT} styles per bot`);
+    }
+
+    return botStyleRepository.create(botId, content);
+  },
+
+  async update(botId: string, styleId: string, userId: string, content: string) {
+    await assertBotAccess(botId, userId);
+
+    const style = await botStyleRepository.findById(styleId);
+    if (!style || style.botId !== botId) {
+      throw new NotFoundError('Style not found');
+    }
+
+    return botStyleRepository.update(styleId, content);
+  },
+
+  async remove(botId: string, styleId: string, userId: string) {
+    await assertBotAccess(botId, userId);
+
+    const style = await botStyleRepository.findById(styleId);
+    if (!style || style.botId !== botId) {
+      throw new NotFoundError('Style not found');
+    }
+
+    await botStyleRepository.delete(styleId);
+  },
+};

--- a/api/src/worker/jobWorker.ts
+++ b/api/src/worker/jobWorker.ts
@@ -2,6 +2,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { jobRepository } from '../repositories/jobRepository.js';
 import { postRepository } from '../repositories/postRepository.js';
 import { botTipRepository } from '../repositories/botTipRepository.js';
+import { botStyleRepository } from '../repositories/botStyleRepository.js';
 import { generateTweet } from '../services/aiService.js';
 import { computeNextScheduledAt } from '../services/scheduler.js';
 import { log } from './activityLog.js';
@@ -138,10 +139,15 @@ async function processJobs(): Promise<void> {
 
         const tips = await botTipRepository.findByBotId(bot.id);
         const recentPosts = await postRepository.findRecentByBotId(bot.id, 10);
+        const styles = await botStyleRepository.findByBotId(bot.id);
+        const selectedStyle =
+          styles.length > 0 ? styles[Math.floor(Math.random() * styles.length)] : null;
+
         const result = await generateTweet(
           bot.prompt,
           tips.map((t: { content: string }) => t.content),
           recentPosts.map((p: { content: string }) => p.content),
+          selectedStyle?.content,
         );
 
         if (!result.success) {
@@ -161,6 +167,7 @@ async function processJobs(): Promise<void> {
           content: result.content,
           status: postStatus,
           scheduledAt,
+          stylePrompt: selectedStyle?.content ?? null,
         });
 
         await jobRepository.markCompleted(job.id);

--- a/web/src/components/PostCard.tsx
+++ b/web/src/components/PostCard.tsx
@@ -230,6 +230,20 @@ export default function PostCard({ post }: PostCardProps) {
           </Typography>
         )}
 
+        {post.stylePrompt && (
+          <Chip
+            label={`Style: ${post.stylePrompt}`}
+            size="small"
+            variant="outlined"
+            sx={{
+              mb: 1,
+              maxWidth: '100%',
+              height: 'auto',
+              '& .MuiChip-label': { whiteSpace: 'normal' },
+            }}
+          />
+        )}
+
         {post.scheduledAt && (
           <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mb: 0.5 }}>
             Scheduled: {formatDate(post.scheduledAt)}

--- a/web/src/hooks/useBotStyles.ts
+++ b/web/src/hooks/useBotStyles.ts
@@ -1,0 +1,85 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { apiClient } from '../lib/apiClient';
+import { queryKeys } from '../lib/queryKeys';
+
+export type BotStyle = {
+  id: string;
+  botId: string;
+  content: string;
+  createdAt: string;
+};
+
+type BotStyleListResponse = {
+  data: BotStyle[];
+};
+
+export function useBotStyles(botId: string | undefined) {
+  return useQuery({
+    queryKey: queryKeys.bots.styles(botId ?? ''),
+    queryFn: async () => {
+      const response = await apiClient.get<BotStyleListResponse>(`/bots/${botId}/styles`);
+      return response.data.data;
+    },
+    enabled: !!botId,
+  });
+}
+
+export function useCreateBotStyle() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({ botId, content }: { botId: string; content: string }) => {
+      const response = await apiClient.post<{ data: BotStyle }>(`/bots/${botId}/styles`, {
+        content,
+      });
+      return response.data.data;
+    },
+    onSuccess: (_data, variables) => {
+      void queryClient.invalidateQueries({
+        queryKey: queryKeys.bots.styles(variables.botId),
+      });
+    },
+  });
+}
+
+export function useUpdateBotStyle() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({
+      botId,
+      styleId,
+      content,
+    }: {
+      botId: string;
+      styleId: string;
+      content: string;
+    }) => {
+      const response = await apiClient.patch<{ data: BotStyle }>(
+        `/bots/${botId}/styles/${styleId}`,
+        { content },
+      );
+      return response.data.data;
+    },
+    onSuccess: (_data, variables) => {
+      void queryClient.invalidateQueries({
+        queryKey: queryKeys.bots.styles(variables.botId),
+      });
+    },
+  });
+}
+
+export function useDeleteBotStyle() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({ botId, styleId }: { botId: string; styleId: string }) => {
+      await apiClient.delete(`/bots/${botId}/styles/${styleId}`);
+    },
+    onSuccess: (_data, variables) => {
+      void queryClient.invalidateQueries({
+        queryKey: queryKeys.bots.styles(variables.botId),
+      });
+    },
+  });
+}

--- a/web/src/hooks/usePosts.ts
+++ b/web/src/hooks/usePosts.ts
@@ -10,6 +10,7 @@ export type Post = {
   content: string;
   status: PostStatus;
   rating: number | null;
+  stylePrompt: string | null;
   scheduledAt: string | null;
   publishedAt: string | null;
   createdAt: string;

--- a/web/src/lib/queryKeys.ts
+++ b/web/src/lib/queryKeys.ts
@@ -7,6 +7,7 @@ export const queryKeys = {
     detail: (id: string) => ['bots', 'detail', id] as const,
     shares: (botId: string) => ['bots', 'shares', botId] as const,
     tips: (botId: string) => ['bots', 'tips', botId] as const,
+    styles: (botId: string) => ['bots', 'styles', botId] as const,
     judges: (botId: string) => ['bots', 'judges', botId] as const,
   },
   posts: {

--- a/web/src/pages/BotEditPage.tsx
+++ b/web/src/pages/BotEditPage.tsx
@@ -1,12 +1,24 @@
+import { useState } from 'react';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import CircularProgress from '@mui/material/CircularProgress';
 import Container from '@mui/material/Container';
+import IconButton from '@mui/material/IconButton';
+import TextField from '@mui/material/TextField';
 import Typography from '@mui/material/Typography';
 import ArrowBackIcon from '@mui/icons-material/ArrowBack';
+import DeleteIcon from '@mui/icons-material/Delete';
+import SaveIcon from '@mui/icons-material/Save';
+import AddIcon from '@mui/icons-material/Add';
 import AppHeader from '../components/AppHeader';
 import BotSetupForm from '../components/BotSetupForm';
 import { useBot, useUpdateBot } from '../hooks/useBot';
+import {
+  useBotStyles,
+  useCreateBotStyle,
+  useUpdateBotStyle,
+  useDeleteBotStyle,
+} from '../hooks/useBotStyles';
 import { useNavigate, useParams } from '@tanstack/react-router';
 
 export default function BotEditPage() {
@@ -14,6 +26,12 @@ export default function BotEditPage() {
   const { bots, isLoading } = useBot();
   const updateBot = useUpdateBot();
   const navigate = useNavigate();
+  const { data: styles, isLoading: stylesLoading } = useBotStyles(botId);
+  const createStyle = useCreateBotStyle();
+  const updateStyle = useUpdateBotStyle();
+  const deleteStyle = useDeleteBotStyle();
+  const [newStyleContent, setNewStyleContent] = useState('');
+  const [editingStyles, setEditingStyles] = useState<Record<string, string>>({});
 
   const bot = bots.find((b) => b.id === botId);
 
@@ -85,6 +103,112 @@ export default function BotEditPage() {
             isLoading={updateBot.isPending}
             submitLabel="Update"
           />
+        </Box>
+
+        <Box sx={{ mt: 4 }}>
+          <Typography variant="h6" gutterBottom>
+            Style Prompts ({styles?.length ?? 0}/5)
+          </Typography>
+          <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+            Add style prompts to vary how posts are generated. A random style will be applied to
+            each new post.
+          </Typography>
+
+          {stylesLoading ? (
+            <CircularProgress size={24} />
+          ) : (
+            <>
+              {styles?.map((style) => {
+                const isEditing = editingStyles[style.id] !== undefined;
+                return (
+                  <Box key={style.id} sx={{ display: 'flex', gap: 1, mb: 1, alignItems: 'start' }}>
+                    <TextField
+                      fullWidth
+                      multiline
+                      minRows={1}
+                      size="small"
+                      value={isEditing ? editingStyles[style.id] : style.content}
+                      onChange={(e) =>
+                        setEditingStyles((prev) => ({ ...prev, [style.id]: e.target.value }))
+                      }
+                      onFocus={() => {
+                        if (!isEditing) {
+                          setEditingStyles((prev) => ({ ...prev, [style.id]: style.content }));
+                        }
+                      }}
+                    />
+                    {isEditing && (
+                      <IconButton
+                        size="small"
+                        color="primary"
+                        onClick={() => {
+                          const content = editingStyles[style.id];
+                          if (content && content.trim()) {
+                            updateStyle.mutate(
+                              { botId: bot.id, styleId: style.id, content: content.trim() },
+                              {
+                                onSuccess: () => {
+                                  setEditingStyles((prev) => {
+                                    const next = { ...prev };
+                                    delete next[style.id];
+                                    return next;
+                                  });
+                                },
+                              },
+                            );
+                          }
+                        }}
+                        disabled={updateStyle.isPending}
+                      >
+                        <SaveIcon fontSize="small" />
+                      </IconButton>
+                    )}
+                    <IconButton
+                      size="small"
+                      color="error"
+                      onClick={() => deleteStyle.mutate({ botId: bot.id, styleId: style.id })}
+                      disabled={deleteStyle.isPending}
+                    >
+                      <DeleteIcon fontSize="small" />
+                    </IconButton>
+                  </Box>
+                );
+              })}
+
+              {(styles?.length ?? 0) < 5 && (
+                <Box sx={{ display: 'flex', gap: 1, mt: 1 }}>
+                  <TextField
+                    fullWidth
+                    multiline
+                    minRows={1}
+                    size="small"
+                    placeholder="e.g., Write in a witty, sarcastic tone with pop culture references"
+                    value={newStyleContent}
+                    onChange={(e) => setNewStyleContent(e.target.value)}
+                  />
+                  <Button
+                    variant="outlined"
+                    size="small"
+                    startIcon={<AddIcon />}
+                    onClick={() => {
+                      if (newStyleContent.trim()) {
+                        createStyle.mutate(
+                          { botId: bot.id, content: newStyleContent.trim() },
+                          {
+                            onSuccess: () => setNewStyleContent(''),
+                          },
+                        );
+                      }
+                    }}
+                    disabled={!newStyleContent.trim() || createStyle.isPending}
+                    sx={{ whiteSpace: 'nowrap' }}
+                  >
+                    Add
+                  </Button>
+                </Box>
+              )}
+            </>
+          )}
         </Box>
       </Container>
     </>


### PR DESCRIPTION
## Summary
- Adds `BotStyle` model (max 5 per bot) with full CRUD API under `GET/POST /bots/:botId/styles` and `PATCH/DELETE /bots/:botId/styles/:styleId`
- During post generation (both job worker and manual draft generation), a random style is selected and passed to the AI prompt, then stored as `stylePrompt` on the created post
- Bot edit page now includes a "Style Prompts" section for managing styles with inline editing
- PostCard displays the style prompt used for generation as a chip

## Test plan
- [ ] Create a bot and add 1-5 style prompts on the edit page
- [ ] Verify max 5 styles limit is enforced
- [ ] Generate drafts and confirm posts receive random style prompts
- [ ] Verify style prompt chip appears on PostCard for styled posts
- [ ] Edit and delete styles, confirm changes persist
- [ ] Run `npx tsc --noEmit` for api, web, shared packages
- [ ] Run Prisma migration against a database

Closes #74

🤖 Generated with [Claude Code](https://claude.com/claude-code)