### PR TITLE
Fix Claude model ID: revert to claude-sonnet-4-20250514

### DIFF
--- a/api/src/services/aiService.ts
+++ b/api/src/services/aiService.ts
@@ -39,7 +39,7 @@ async function callClaude(
   systemPrompt?: string,
 ): Promise<string> {
   const response = await client.messages.create({
-    model: 'claude-sonnet-4-6-20250627',
+    model: 'claude-sonnet-4-20250514',
     max_tokens: 300,
     system: systemPrompt ?? SYSTEM_PROMPT,
     messages: [{ role: 'user', content: prompt }],
@@ -60,7 +60,7 @@ async function callClaudeWithMessages(
   maxTokens = 300,
 ): Promise<string> {
   const response = await client.messages.create({
-    model: 'claude-sonnet-4-6-20250627',
+    model: 'claude-sonnet-4-20250514',
     max_tokens: maxTokens,
     system: systemPrompt,
     messages,

--- a/api/src/services/judgeAiService.ts
+++ b/api/src/services/judgeAiService.ts
@@ -39,7 +39,7 @@ export async function reviewPostWithJudge(
   const systemPrompt = buildSystemPrompt(judgeName, judgePrompt);
 
   const response = await client.messages.create({
-    model: 'claude-sonnet-4-6-20250627',
+    model: 'claude-sonnet-4-20250514',
     max_tokens: 300,
     system: systemPrompt,
     messages: [


### PR DESCRIPTION
## Summary
- Revert model ID from `claude-sonnet-4-6-20250627` to `claude-sonnet-4-20250514`
- The Sonnet 4.6 model ID doesn't exist on the Anthropic API yet, causing 404 on all AI calls

## Test plan
- [ ] Ask Judges produces reviews
- [ ] Post generation works

🤖 Generated with [Claude Code](https://claude.com/claude-code)