### PR TITLE
Fix: revert Claude model to claude-sonnet-4-20250514

### DIFF
--- a/api/src/services/aiService.ts
+++ b/api/src/services/aiService.ts
@@ -39,7 +39,7 @@ async function callClaude(
   systemPrompt?: string,
 ): Promise<string> {
   const response = await client.messages.create({
-    model: 'claude-sonnet-4-6-20250627',
+    model: 'claude-sonnet-4-20250514',
     max_tokens: 300,
     system: systemPrompt ?? SYSTEM_PROMPT,
     messages: [{ role: 'user', content: prompt }],
@@ -60,7 +60,7 @@ async function callClaudeWithMessages(
   maxTokens = 300,
 ): Promise<string> {
   const response = await client.messages.create({
-    model: 'claude-sonnet-4-6-20250627',
+    model: 'claude-sonnet-4-20250514',
     max_tokens: maxTokens,
     system: systemPrompt,
     messages,

--- a/api/src/services/judgeAiService.ts
+++ b/api/src/services/judgeAiService.ts
@@ -39,7 +39,7 @@ export async function reviewPostWithJudge(
   const systemPrompt = buildSystemPrompt(judgeName, judgePrompt);
 
   const response = await client.messages.create({
-    model: 'claude-sonnet-4-6-20250627',
+    model: 'claude-sonnet-4-20250514',
     max_tokens: 300,
     system: systemPrompt,
     messages: [


### PR DESCRIPTION
## Summary
- Revert model ID to `claude-sonnet-4-20250514` (Claude Sonnet 4)
- `claude-sonnet-4-6-20250627` does not exist on the Anthropic API, causing 404 on all AI calls

## Test plan
- [ ] Post generation works
- [ ] Ask Judges produces reviews

🤖 Generated with [Claude Code](https://claude.com/claude-code)