### PR TITLE
Move version to footer, add EHE branding, 3-row style textareas

### DIFF
--- a/web/src/components/AppFooter.tsx
+++ b/web/src/components/AppFooter.tsx
@@ -1,0 +1,37 @@
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+import Tooltip from '@mui/material/Tooltip';
+
+declare const __GIT_SHA__: string;
+declare const __GIT_DATE__: string;
+
+export default function AppFooter() {
+  return (
+    <Box
+      component="footer"
+      sx={{
+        py: 2,
+        px: 3,
+        mt: 'auto',
+        display: 'flex',
+        justifyContent: 'space-between',
+        alignItems: 'center',
+        borderTop: 1,
+        borderColor: 'divider',
+      }}
+    >
+      <Typography variant="caption" color="text.secondary">
+        by EHE Venture Studio
+      </Typography>
+      <Tooltip title={`${__GIT_SHA__} (${__GIT_DATE__})`}>
+        <Typography
+          variant="caption"
+          color="text.secondary"
+          sx={{ cursor: 'default', userSelect: 'none' }}
+        >
+          {__GIT_SHA__}
+        </Typography>
+      </Tooltip>
+    </Box>
+  );
+}

--- a/web/src/components/AppHeader.tsx
+++ b/web/src/components/AppHeader.tsx
@@ -4,11 +4,7 @@ import Typography from '@mui/material/Typography';
 import Button from '@mui/material/Button';
 import Box from '@mui/material/Box';
 import { Link } from '@tanstack/react-router';
-import Tooltip from '@mui/material/Tooltip';
 import { useAuth, useLogoutMutation } from '../hooks/useAuth';
-
-declare const __GIT_SHA__: string;
-declare const __GIT_DATE__: string;
 
 export default function AppHeader() {
   const { user } = useAuth();
@@ -25,17 +21,9 @@ export default function AppHeader() {
   return (
     <AppBar position="static">
       <Toolbar>
-        <Typography variant="h6" component="div" sx={{ mr: 1 }}>
+        <Typography variant="h6" component="div" sx={{ mr: 2 }}>
           X Bot Platform
         </Typography>
-        <Tooltip title={`${__GIT_SHA__} (${__GIT_DATE__})`}>
-          <Typography
-            variant="caption"
-            sx={{ mr: 2, opacity: 0.5, cursor: 'default', userSelect: 'none' }}
-          >
-            {__GIT_SHA__}
-          </Typography>
-        </Tooltip>
         {user && (
           <>
             <Box sx={{ display: 'flex', gap: 1, flexGrow: 1 }}>

--- a/web/src/pages/BotEditPage.tsx
+++ b/web/src/pages/BotEditPage.tsx
@@ -125,7 +125,7 @@ export default function BotEditPage() {
                     <TextField
                       fullWidth
                       multiline
-                      minRows={1}
+                      minRows={3}
                       size="small"
                       value={isEditing ? editingStyles[style.id] : style.content}
                       onChange={(e) =>
@@ -180,7 +180,7 @@ export default function BotEditPage() {
                   <TextField
                     fullWidth
                     multiline
-                    minRows={1}
+                    minRows={3}
                     size="small"
                     placeholder="e.g., Write in a witty, sarcastic tone with pop culture references"
                     value={newStyleContent}

--- a/web/src/routes/router.tsx
+++ b/web/src/routes/router.tsx
@@ -5,8 +5,10 @@ import {
   redirect,
   Outlet,
 } from '@tanstack/react-router';
+import Box from '@mui/material/Box';
 import { QueryClient } from '@tanstack/react-query';
 import { apiClient } from '../lib/apiClient';
+import AppFooter from '../components/AppFooter';
 import LoginPage from '../pages/LoginPage';
 import DashboardPage from '../pages/DashboardPage';
 import PostsPage from '../pages/PostsPage';
@@ -24,8 +26,19 @@ async function checkAuth(): Promise<boolean> {
   }
 }
 
+function RootLayout() {
+  return (
+    <Box sx={{ display: 'flex', flexDirection: 'column', minHeight: '100vh' }}>
+      <Box sx={{ flex: 1 }}>
+        <Outlet />
+      </Box>
+      <AppFooter />
+    </Box>
+  );
+}
+
 const rootRoute = createRootRoute({
-  component: Outlet,
+  component: RootLayout,
 });
 
 const loginRoute = createRoute({


### PR DESCRIPTION
## Summary
- Move git SHA/version from header to a discrete footer
- Add "by EHE Venture Studio" to footer
- Style prompt fields now use 3-row textareas instead of single-line inputs

🤖 Generated with [Claude Code](https://claude.com/claude-code)