### PR TITLE
Show web and API versions in footer with mismatch highlight

### DIFF
--- a/api/src/config/index.ts
+++ b/api/src/config/index.ts
@@ -9,6 +9,7 @@ export const config = {
   },
   app: {
     version: process.env.APP_VERSION || '0.1.0',
+    gitSha: process.env.GIT_SHA || 'dev',
     baseUrl: process.env.API_BASE_URL || 'http://localhost:3001',
     frontendUrl: process.env.FRONTEND_URL || 'http://localhost:3000',
   },

--- a/api/src/controllers/healthController.ts
+++ b/api/src/controllers/healthController.ts
@@ -6,6 +6,7 @@ export const healthController = {
     res.status(200).json({
       status: 'ok',
       version: config.app.version,
+      gitSha: config.app.gitSha,
       timestamp: new Date().toISOString(),
     });
   },

--- a/render.yaml
+++ b/render.yaml
@@ -11,7 +11,7 @@ services:
     plan: free
     rootDir: .
     buildCommand: npm ci --include=dev && cd api && npx prisma generate && cd .. && npm run build --workspace=shared && npm run build --workspace=api
-    startCommand: cd api && npm run start
+    startCommand: cd api && GIT_SHA=$(echo $RENDER_GIT_COMMIT | cut -c1-7) npm run start
     healthCheckPath: /api/health
     envVars:
       - key: NODE_VERSION

--- a/web/src/components/AppFooter.tsx
+++ b/web/src/components/AppFooter.tsx
@@ -1,11 +1,24 @@
+import { useEffect, useState } from 'react';
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
 import Tooltip from '@mui/material/Tooltip';
+import { apiClient } from '../lib/apiClient';
 
 declare const __GIT_SHA__: string;
 declare const __GIT_DATE__: string;
 
 export default function AppFooter() {
+  const [apiSha, setApiSha] = useState<string | null>(null);
+
+  useEffect(() => {
+    apiClient
+      .get<{ gitSha: string }>('/health')
+      .then((res) => setApiSha(res.data.gitSha))
+      .catch(() => setApiSha(null));
+  }, []);
+
+  const mismatch = apiSha !== null && apiSha !== 'dev' && apiSha !== __GIT_SHA__;
+
   return (
     <Box
       component="footer"
@@ -23,13 +36,24 @@ export default function AppFooter() {
       <Typography variant="caption" color="text.secondary">
         by EHE Venture Studio
       </Typography>
-      <Tooltip title={`${__GIT_SHA__} (${__GIT_DATE__})`}>
+      <Tooltip
+        title={
+          mismatch
+            ? `Version mismatch! Web: ${__GIT_SHA__} (${__GIT_DATE__}) / API: ${apiSha}`
+            : `${__GIT_SHA__} (${__GIT_DATE__})`
+        }
+      >
         <Typography
           variant="caption"
-          color="text.secondary"
-          sx={{ cursor: 'default', userSelect: 'none' }}
+          sx={{
+            cursor: 'default',
+            userSelect: 'none',
+            color: mismatch ? 'error.main' : 'text.secondary',
+            fontWeight: mismatch ? 'bold' : 'normal',
+          }}
         >
-          {__GIT_SHA__}
+          web: {__GIT_SHA__}
+          {apiSha && ` / api: ${apiSha}`}
         </Typography>
       </Tooltip>
     </Box>


### PR DESCRIPTION
## Summary
- API health endpoint now returns `gitSha` from `GIT_SHA` env var
- Render start command injects `RENDER_GIT_COMMIT` (short) as `GIT_SHA`
- Footer shows `web: abc1234 / api: abc1234` discretely
- Versions highlighted red when they don't match

## Test plan
- [ ] CI passes
- [ ] Footer shows both versions
- [ ] Mismatch highlighted when deploying only one side

🤖 Generated with [Claude Code](https://claude.com/claude-code)