### PR TITLE
Fix API git SHA showing 'dev' on Render

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ coverage/
 api/src/generated/
 web/playwright-report/
 web/test-results/
+api/GIT_SHA

--- a/render.yaml
+++ b/render.yaml
@@ -10,8 +10,8 @@ services:
     runtime: node
     plan: free
     rootDir: .
-    buildCommand: npm ci --include=dev && cd api && npx prisma generate && cd .. && npm run build --workspace=shared && npm run build --workspace=api
-    startCommand: cd api && GIT_SHA=$(echo $RENDER_GIT_COMMIT | cut -c1-7) npm run start
+    buildCommand: npm ci --include=dev && cd api && npx prisma generate && cd .. && npm run build --workspace=shared && npm run build --workspace=api && echo "${RENDER_GIT_COMMIT:-unknown}" | cut -c1-7 > api/GIT_SHA
+    startCommand: cd api && GIT_SHA=$(cat GIT_SHA 2>/dev/null || echo dev) npm run start
     healthCheckPath: /api/health
     envVars:
       - key: NODE_VERSION


### PR DESCRIPTION
## Summary
- `RENDER_GIT_COMMIT` is only available during the build phase, not at runtime
- Write the SHA to `api/GIT_SHA` file during build, read it at startup
- Added `api/GIT_SHA` to `.gitignore`

## Test plan
- [ ] Deploy to Render and verify footer shows actual git SHA for API instead of "dev"

🤖 Generated with [Claude Code](https://claude.com/claude-code)