### PR TITLE
Limit main prompt textarea to 20 lines with scroll

### DIFF
--- a/web/src/components/BotSetupForm.tsx
+++ b/web/src/components/BotSetupForm.tsx
@@ -110,6 +110,7 @@ export default function BotSetupForm({
         label="Bot Prompt"
         multiline
         minRows={8}
+        maxRows={20}
         value={values.prompt}
         onChange={(e) => setValues((v) => ({ ...v, prompt: e.target.value }))}
         error={!!errors['prompt']}
@@ -118,6 +119,9 @@ export default function BotSetupForm({
           'Describe how your bot should write posts. This can be multiple paragraphs.'
         }
         fullWidth
+        InputProps={{
+          sx: { overflowY: 'auto' },
+        }}
       />
 
       <FormControl>


### PR DESCRIPTION
## Summary
- Set `maxRows={20}` on the Bot Prompt `TextField` in `BotSetupForm` so the textarea caps at 20 visible lines
- Added `overflowY: 'auto'` on the input so content scrolls when it exceeds 20 lines

Closes #86

## Test plan
- [ ] Open BotEditPage, enter text exceeding 20 lines in the main prompt field
- [ ] Verify the textarea stops growing at 20 rows and becomes scrollable
- [ ] Verify short prompts (< 8 lines) still start at 8 rows minimum

🤖 Generated with [Claude Code](https://claude.com/claude-code)