### PR TITLE
Style prompt tabs: truncate titles, show full on hover

### DIFF
--- a/web/src/pages/BotEditPage.tsx
+++ b/web/src/pages/BotEditPage.tsx
@@ -7,6 +7,7 @@ import Switch from '@mui/material/Switch';
 import Tab from '@mui/material/Tab';
 import Tabs from '@mui/material/Tabs';
 import TextField from '@mui/material/TextField';
+import Tooltip from '@mui/material/Tooltip';
 import Typography from '@mui/material/Typography';
 import FormControlLabel from '@mui/material/FormControlLabel';
 import ArrowBackIcon from '@mui/icons-material/ArrowBack';
@@ -145,8 +146,23 @@ export default function BotEditPage() {
                 {styles?.map((style, index) => (
                   <Tab
                     key={style.id}
-                    label={getTabLabel(style, index)}
+                    label={
+                      <Tooltip title={getTabLabel(style, index)} enterDelay={400}>
+                        <span
+                          style={{
+                            display: 'block',
+                            maxWidth: 160,
+                            overflow: 'hidden',
+                            textOverflow: 'ellipsis',
+                            whiteSpace: 'nowrap',
+                          }}
+                        >
+                          {getTabLabel(style, index)}
+                        </span>
+                      </Tooltip>
+                    }
                     sx={{
+                      maxWidth: 200,
                       opacity: style.active ? 1 : 0.5,
                       textTransform: 'none',
                     }}


### PR DESCRIPTION
## Summary
- Wrap each style prompt tab label in an MUI `Tooltip` so the full title appears on hover (with 400ms delay)
- Apply CSS text-overflow ellipsis (`maxWidth: 160px`) to truncate long labels
- Tabs already use `variant="scrollable"` and `scrollButtons="auto"` to fit within the container

Closes #88

## Test plan
- [ ] Open the bot edit page with multiple style prompts (some with long content)
- [ ] Verify tabs fit within the container and scroll buttons appear when needed
- [ ] Verify long tab labels are truncated with ellipsis
- [ ] Hover over a truncated tab and confirm the full title appears in a tooltip

🤖 Generated with [Claude Code](https://claude.com/claude-code)