### PR TITLE
Style tabs: fit all in view, no horizontal scroll

### DIFF
--- a/web/src/pages/BotEditPage.tsx
+++ b/web/src/pages/BotEditPage.tsx
@@ -144,8 +144,7 @@ export default function BotEditPage() {
               <Tabs
                 value={activeTab}
                 onChange={(_e, newValue: number) => setActiveTab(newValue)}
-                variant="scrollable"
-                scrollButtons="auto"
+                variant="fullWidth"
               >
                 {styles?.map((style, index) => (
                   <Tab
@@ -155,7 +154,6 @@ export default function BotEditPage() {
                         <span
                           style={{
                             display: 'block',
-                            maxWidth: 160,
                             overflow: 'hidden',
                             textOverflow: 'ellipsis',
                             whiteSpace: 'nowrap',
@@ -166,7 +164,7 @@ export default function BotEditPage() {
                       </Tooltip>
                     }
                     sx={{
-                      maxWidth: 200,
+                      minWidth: 0,
                       opacity: style.active ? 1 : 0.5,
                       textTransform: 'none',
                     }}


### PR DESCRIPTION
## Summary
- Switch from `variant="scrollable"` to `variant="fullWidth"` so all tabs share space equally
- Set `minWidth: 0` on tabs so they can shrink, removed fixed `maxWidth`
- Titles truncate with ellipsis, full title shown on hover

## Test plan
- [ ] Verify all 5 style tabs + add tab fit without horizontal scrolling
- [ ] Long titles truncate with ellipsis
- [ ] Hover shows full title in tooltip

🤖 Generated with [Claude Code](https://claude.com/claude-code)