### PR TITLE
Flag draft posts containing invalid/broken URLs

### DIFF
--- a/api/prisma/migrations/20260315030000_add_post_flagging/migration.sql
+++ b/api/prisma/migrations/20260315030000_add_post_flagging/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "Post" ADD COLUMN     "flagReasons" TEXT[],
+ADD COLUMN     "flagged" BOOLEAN NOT NULL DEFAULT false;

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -64,6 +64,8 @@ model Post {
   content     String    @db.Text
   status      String    @default("draft")
   rating      Int?
+  flagged     Boolean   @default(false)
+  flagReasons String[]
   scheduledAt DateTime?
   publishedAt DateTime?
   createdAt   DateTime  @default(now())

--- a/api/src/controllers/botController.ts
+++ b/api/src/controllers/botController.ts
@@ -6,6 +6,7 @@ import { postRepository } from '../repositories/postRepository.js';
 import { botTipRepository } from '../repositories/botTipRepository.js';
 import { botStyleRepository } from '../repositories/botStyleRepository.js';
 import { paginationSchema, uuidSchema } from '../utils/validation.js';
+import { checkAndFlagPost } from '../services/urlValidationService.js';
 
 const createBotSchema = z.object({
   platform: z.enum(['x']).default('x'),
@@ -128,6 +129,8 @@ export const botController = {
             stylePrompt: selectedStyle?.content ?? null,
             styleTitle: selectedStyle?.title || null,
           });
+          // Fire-and-forget URL validation — don't block the response
+          checkAndFlagPost(post.id).catch(console.error);
           posts.push(post);
         }
       }

--- a/api/src/repositories/postRepository.ts
+++ b/api/src/repositories/postRepository.ts
@@ -181,6 +181,16 @@ export const postRepository = {
     });
   },
 
+  async flagPost(id: string, reasons: string[]) {
+    return prisma.post.update({
+      where: { id },
+      data: {
+        flagged: true,
+        flagReasons: { push: reasons },
+      },
+    });
+  },
+
   async findRecentByBotId(botId: string, limit = 10) {
     return prisma.post.findMany({
       where: {

--- a/api/src/services/urlValidationService.ts
+++ b/api/src/services/urlValidationService.ts
@@ -1,0 +1,72 @@
+import { postRepository } from '../repositories/postRepository.js';
+
+const URL_REGEX = /https?:\/\/[^\s)>\]"]+/g;
+const REQUEST_TIMEOUT_MS = 5000;
+
+export type UrlValidationResult = {
+  url: string;
+  valid: boolean;
+  reason?: string;
+};
+
+export function extractUrls(text: string): string[] {
+  return [...text.matchAll(URL_REGEX)].map((m) => m[0]);
+}
+
+export async function validateUrls(urls: string[]): Promise<UrlValidationResult[]> {
+  return Promise.all(urls.map((url) => validateSingleUrl(url)));
+}
+
+async function validateSingleUrl(url: string): Promise<UrlValidationResult> {
+  try {
+    const response = await fetch(url, {
+      method: 'HEAD',
+      signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+      redirect: 'follow',
+    });
+
+    // If HEAD is not allowed, fallback to GET
+    if (response.status === 405) {
+      const getResponse = await fetch(url, {
+        method: 'GET',
+        signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+        redirect: 'follow',
+      });
+      if (getResponse.status >= 200 && getResponse.status < 400) {
+        return { url, valid: true };
+      }
+      return { url, valid: false, reason: `HTTP ${getResponse.status}` };
+    }
+
+    if (response.status >= 200 && response.status < 400) {
+      return { url, valid: true };
+    }
+
+    return { url, valid: false, reason: `HTTP ${response.status}` };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    if (message.includes('timeout') || message.includes('TimeoutError')) {
+      return { url, valid: false, reason: 'Timeout' };
+    }
+    if (message.includes('ENOTFOUND') || message.includes('getaddrinfo')) {
+      return { url, valid: false, reason: 'DNS failure' };
+    }
+    return { url, valid: false, reason: message };
+  }
+}
+
+export async function checkAndFlagPost(postId: string): Promise<void> {
+  const post = await postRepository.findById(postId);
+  if (!post) return;
+
+  const urls = extractUrls(post.content);
+  if (urls.length === 0) return;
+
+  const results = await validateUrls(urls);
+  const invalid = results.filter((r) => !r.valid);
+
+  if (invalid.length > 0) {
+    const reasons = invalid.map((r) => `Invalid URL: ${r.url} (${r.reason})`);
+    await postRepository.flagPost(postId, reasons);
+  }
+}

--- a/api/src/worker/jobWorker.ts
+++ b/api/src/worker/jobWorker.ts
@@ -5,6 +5,7 @@ import { botTipRepository } from '../repositories/botTipRepository.js';
 import { botStyleRepository } from '../repositories/botStyleRepository.js';
 import { generateTweet } from '../services/aiService.js';
 import { computeNextScheduledAt } from '../services/scheduler.js';
+import { checkAndFlagPost } from '../services/urlValidationService.js';
 import { log } from './activityLog.js';
 
 const POLL_INTERVAL_MS = parseInt(process.env.WORKER_POLL_INTERVAL_MS || '30000', 10);
@@ -158,21 +159,37 @@ async function processJobs(): Promise<void> {
           continue;
         }
 
-        const postStatus = bot.postMode === 'auto' ? 'scheduled' : 'draft';
-        const scheduledAt = bot.postMode === 'auto' ? new Date() : null;
-
-        await postRepository.create({
+        const post = await postRepository.create({
           botId: bot.id,
           jobId: job.id,
           content: result.content,
-          status: postStatus,
-          scheduledAt,
+          status: 'draft',
+          scheduledAt: null,
           stylePrompt: selectedStyle?.content ?? null,
           styleTitle: selectedStyle?.title || null,
         });
 
+        // Await URL validation before deciding publish status
+        await checkAndFlagPost(post.id);
+
+        // Re-fetch post to check if it was flagged
+        const checkedPost = await postRepository.findById(post.id);
+        const isFlagged = checkedPost?.flagged ?? false;
+
+        // Only auto-schedule if not flagged and bot is in auto mode
+        if (bot.postMode === 'auto' && !isFlagged) {
+          await postRepository.update(post.id, {
+            status: 'scheduled',
+            scheduledAt: new Date(),
+          });
+        }
+
+        const finalStatus = bot.postMode === 'auto' && !isFlagged ? 'scheduled' : 'draft';
         await jobRepository.markCompleted(job.id);
-        log('jobWorker', `Job ${job.id} completed — created ${postStatus} post`);
+        log(
+          'jobWorker',
+          `Job ${job.id} completed — created ${finalStatus} post${isFlagged ? ' (flagged)' : ''}`,
+        );
         console.log(`[jobWorker] Job ${job.id} completed successfully`);
       } catch (err) {
         const errorMsg = err instanceof Error ? `${err.message}\n${err.stack}` : String(err);

--- a/web/src/components/PostCard.tsx
+++ b/web/src/components/PostCard.tsx
@@ -13,6 +13,7 @@ import DialogContent from '@mui/material/DialogContent';
 import DialogActions from '@mui/material/DialogActions';
 import Alert from '@mui/material/Alert';
 import CircularProgress from '@mui/material/CircularProgress';
+import Tooltip from '@mui/material/Tooltip';
 import IconButton from '@mui/material/IconButton';
 import DeleteIcon from '@mui/icons-material/Delete';
 import type { Post, PostStatus } from '../hooks/usePosts';
@@ -188,7 +189,14 @@ export default function PostCard({ post }: PostCardProps) {
         <Box
           sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', mb: 1 }}
         >
-          <Chip label={post.status} color={statusColors[post.status]} size="small" />
+          <Box sx={{ display: 'flex', gap: 1, alignItems: 'center' }}>
+            <Chip label={post.status} color={statusColors[post.status]} size="small" />
+            {post.flagged && (
+              <Tooltip title={post.flagReasons.join('\n')}>
+                <Chip label="Flagged" color="warning" size="small" />
+              </Tooltip>
+            )}
+          </Box>
           <Typography variant="caption" color="text.secondary">
             {formatDate(post.createdAt)}
           </Typography>

--- a/web/src/hooks/usePosts.ts
+++ b/web/src/hooks/usePosts.ts
@@ -10,6 +10,8 @@ export type Post = {
   content: string;
   status: PostStatus;
   rating: number | null;
+  flagged: boolean;
+  flagReasons: string[];
   stylePrompt: string | null;
   styleTitle: string | null;
   scheduledAt: string | null;


### PR DESCRIPTION
## Summary
- Adds `flagged` and `flagReasons` fields to the Post model with a Prisma migration
- New `urlValidationService` extracts URLs from post content and validates them via HEAD requests (with GET fallback), flagging posts that contain broken/unreachable links
- In the bot controller, URL validation runs fire-and-forget so draft generation stays fast
- In the job worker, URL validation is awaited before deciding to auto-publish — flagged posts remain as drafts
- Frontend shows a warning "Flagged" chip with tooltip listing reasons on PostCard

Closes #95

## Test plan
- [ ] Generate a draft post containing a known-broken URL (e.g., `https://example.com/nonexistent-page-404`) and verify it gets flagged
- [ ] Generate a draft post with only valid URLs and verify it is not flagged
- [ ] Generate a draft post with no URLs and verify it is not flagged
- [ ] In auto mode, verify a flagged post stays as draft and is not auto-scheduled
- [ ] Verify the "Flagged" chip appears in the UI with correct tooltip reasons
- [ ] Run `npx prisma migrate deploy` and verify the migration applies cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)