### PR TITLE
feat: push Docker image to GHCR on successful main builds

### DIFF
--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -39,15 +39,37 @@ jobs:
       - name: Typecheck Web
         run: npx tsc -p web/tsconfig.json --noEmit
 
-  build:
-    name: Build Docker Image
+  build-and-push:
+    name: Build & Push Docker Image
     runs-on: ubuntu-latest
-    needs: lint-format-typecheck
+    needs: [lint-format-typecheck, e2e-web]
+    permissions:
+      contents: read
+      packages: write
+    env:
+      REGISTRY: ghcr.io
+      IMAGE_NAME: ${{ github.repository }}
     steps:
       - uses: actions/checkout@v5
 
-      - name: Build Docker image
-        run: docker build -t x-bot-app:ci .
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
   e2e-web:
     name: E2E Tests (Playwright)


### PR DESCRIPTION
## Summary
- Replace the standalone `build` job with `build-and-push` that runs after both lint and E2E tests pass
- On `main` pushes: builds and pushes `ghcr.io/timeboxed-tech/x-bot-app-claude-v1:latest`
- On PRs: builds the image (validation only), does not push
- Uses Docker Buildx with GitHub Actions cache for faster builds

## Test plan
- [ ] Verify PR CI builds the image but does not push
- [ ] Verify merge to main pushes `:latest` to GHCR
- [ ] Verify image is visible at `ghcr.io/timeboxed-tech/x-bot-app-claude-v1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)