### PR TITLE
feat: add DB check to health endpoint and /health/ping

### DIFF
--- a/api/src/controllers/healthController.ts
+++ b/api/src/controllers/healthController.ts
@@ -1,13 +1,30 @@
 import { Request, Response } from 'express';
 import { config } from '../config/index.js';
+import { prisma } from '../utils/prisma.js';
 
 export const healthController = {
-  check(_req: Request, res: Response): void {
-    res.status(200).json({
-      status: 'ok',
-      version: config.app.version,
-      gitSha: config.app.gitSha,
-      timestamp: new Date().toISOString(),
-    });
+  async check(_req: Request, res: Response): Promise<void> {
+    try {
+      await prisma.$queryRaw`SELECT 1`;
+      res.status(200).json({
+        status: 'ok',
+        version: config.app.version,
+        gitSha: config.app.gitSha,
+        database: 'connected',
+        timestamp: new Date().toISOString(),
+      });
+    } catch {
+      res.status(503).json({
+        status: 'error',
+        version: config.app.version,
+        gitSha: config.app.gitSha,
+        database: 'disconnected',
+        timestamp: new Date().toISOString(),
+      });
+    }
+  },
+
+  ping(_req: Request, res: Response): void {
+    res.status(200).json({ status: 'ok' });
   },
 };

--- a/api/src/routes/healthRoutes.ts
+++ b/api/src/routes/healthRoutes.ts
@@ -4,5 +4,6 @@ import { healthController } from '../controllers/healthController.js';
 const router = Router();
 
 router.get('/', healthController.check);
+router.get('/ping', healthController.ping);
 
 export default router;


### PR DESCRIPTION
## Summary
- `GET /api/health` now runs `SELECT 1` to verify DB connectivity; returns 503 if DB is unreachable
- `GET /api/health/ping` returns `{"status": "ok"}` with no DB call

## Test plan
- [ ] CI passes (lint, typecheck, E2E, Docker build)
- [ ] `GET /api/health` returns 200 with `"database": "connected"` when DB is up
- [ ] `GET /api/health` returns 503 with `"database": "disconnected"` when DB is down
- [ ] `GET /api/health/ping` returns 200 with `{"status": "ok"}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)